### PR TITLE
Requirements using sphinxcontrib.needs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -211,3 +211,8 @@ linkcheck_anchors = False
 intersphinx_mapping.update({
     'pip': ('https://pip.pypa.io/en/stable/', None),
 })
+
+
+# -- Options for the sphinxcontrib.needs extension ----------------------------
+
+extensions += ["sphinxcontrib.needs"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,6 +51,15 @@ Developer Documentation
    testing
    related
 
+*******
+Modules
+*******
+
+.. toctree::
+   :maxdepth: 1
+
+   reference/tests
+
 ***************
 Project Details
 ***************

--- a/docs/reference/tests.rst
+++ b/docs/reference/tests.rst
@@ -1,0 +1,8 @@
+``m4opt.tests``
+===============
+
+.. automodule:: m4opt.tests.test_cplex
+   :members:
+
+.. automodule:: m4opt.tests.test_gurobi
+   :members:

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -1,2 +1,29 @@
 Requirements
 ============
+
+
+.. req:: The software must support the following kinds of observers:
+   :id: OBSERVER
+
+    * :np:`(TERRESTRIAL) Fixed relative to the surface of the Earth`
+    * :np:`(EARTH_SATELLITE) In an Earth orbit described by a TLE`
+
+
+.. req:: The software must support the following kinds of constraints:
+   :id: CONSTRAINT
+
+    * :np:`(AIRMASS) Limits on airmass or sun elevation angle`
+    * :np:`(ALTITUDE) Limits on the altitude angle above the horizon`
+
+
+.. req:: Unit tests that exceed solver license limits must be skipped:
+   :id: PROBLEM_SIZE_LIMITS
+
+   * :np:`(CPLEX) For CPLEX`
+   * :np:`(GUROBI) For Gurobi`
+
+
+.. needtable::
+   :columns: id;title;incoming as "Tested by"
+   :style: table
+   :types: req

--- a/m4opt/tests/test_cplex.py
+++ b/m4opt/tests/test_cplex.py
@@ -2,6 +2,10 @@ from ..cplex import big_cplex_problem, small_cplex_problem
 
 
 def test_big_cplex_problem():
+    """
+    .. test:: Test a large CPLEX problem
+       :links: PROBLEM_SIZE_LIMITS.CPLEX
+    """
     big_cplex_problem()
 
 

--- a/m4opt/tests/test_gurobi.py
+++ b/m4opt/tests/test_gurobi.py
@@ -2,6 +2,10 @@ from ..gurobi import big_gurobi_problem, small_gurobi_problem
 
 
 def test_big_gurobi_problem():
+    """
+    .. test:: Test a large Gurobi problem
+       :links: PROBLEM_SIZE_LIMITS.GUROBI
+    """
     big_gurobi_problem()
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ test =
     pytest-astropy
 docs =
     sphinx-astropy
+    sphinxcontrib-needs
 
 [options.package_data]
 m4opt = data/*


### PR DESCRIPTION
NPR 7150 says:

> The project manager shall perform, record, and maintain bi-directional traceability between the following software elements: (See Table in 3.12.1)

This is an example of tracking requirements and test cases using [sphinxcontrib.needs](https://sphinxcontrib-needs.readthedocs.io/en/latest/). There is also [sphinx-traceability-extension](https://github.com/melexis/sphinx-traceability-extension).