### PR TITLE
Enable CI tests for Python 3.10

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -27,10 +27,15 @@ jobs:
             python: 3.8
             toxenv: py38-test
 
-          - name: Python 3.9 with all optional dependencies and coverage checking
+          - name: Python 3.9 with minimal dependencies
             os: ubuntu-latest
             python: 3.9
-            toxenv: py39-test-alldeps-cov
+            toxenv: py39-test
+
+          - name: Python 3.10 with all optional dependencies and coverage checking
+            os: ubuntu-latest
+            python: '3.10'
+            toxenv: py10-test-alldeps-cov
 
           # - name: OS X - Python 3.8 with all optional dependencies
           #   os: macos-latest

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{38,39}-test{,-alldeps,-devdeps}{,-cov}
-    py{38,39}-test-numpy{116,117,118}
-    py{38,39}-test-astropy{30,40,lts}
+    py{38,39,10}-test{,-alldeps,-devdeps}{,-cov}
+    py{38,39,10}-test-numpy{116,117,118}
+    py{38,39,10}-test-astropy{30,40,lts}
     build_docs
     linkcheck
     codestyle


### PR DESCRIPTION
Both cplex and gurobipy now have wheels for Python 3.10.