### PR TITLE
Adding risk tracking and assessment page to docs

### DIFF
--- a/docs/_static/css/risk_table.css
+++ b/docs/_static/css/risk_table.css
@@ -1,0 +1,122 @@
+table.risktable tbody tr {height: 50px;width:100px;}
+
+table.risktable th {
+    background-color: rgb(255, 255, 255);
+    border-style: solid solid solid solid;
+    border-width: 0px 0px 0px 0px;
+    border-color: #000000;
+    text-align: center;
+}
+table.risktable td {
+    border-style: solid solid solid solid;
+    border-width: 0px 0px 0px 0px;
+    border-color: #000000;
+    text-align: center;
+}
+
+table.risktable tr {
+    border-style: solid solid solid solid;
+    border-width: 0px 0px 0px 0px;
+    border-color: #000000;
+    text-align: center;
+}
+
+table.risktable tr:nth-child(1) td:nth-child(3){
+    background-color: #63f363;
+}
+
+table.risktable tr:nth-child(2) td:nth-child(2){
+    background-color: #63f363;
+}
+
+table.risktable tr:nth-child(3) td:nth-child(2){
+    background-color: #63f363;
+}
+
+table.risktable tr:nth-child(4) td:nth-child(2){
+    background-color: #63f363;
+}
+
+table.risktable tr:nth-child(5) td:nth-child(2){
+    background-color: #63f363;
+}
+
+table.risktable tr:nth-child(1) td:nth-child(4){
+    background-color: #f3f363;
+}
+
+table.risktable tr:nth-child(2) td:nth-child(3){
+    background-color: #f3f363;
+}
+
+table.risktable tr:nth-child(3) td:nth-child(3){
+    background-color: #63f363;
+}
+table.risktable tr:nth-child(4) td:nth-child(3){
+    background-color: #63f363;
+}
+table.risktable tr:nth-child(5) td:nth-child(3){
+    background-color: #63f363;
+}
+
+table.risktable tr:nth-child(1) td:nth-child(5){
+    background-color: #f36363;
+}
+
+table.risktable tr:nth-child(2) td:nth-child(4){
+    background-color: #f3f363;
+}
+
+table.risktable tr:nth-child(3) td:nth-child(4){
+    background-color: #f3f363;
+}
+table.risktable tr:nth-child(4) td:nth-child(4){
+    background-color: #f3f363;
+}
+table.risktable tr:nth-child(5) td:nth-child(4){
+    background-color: #63f363;
+}
+
+table.risktable tr:nth-child(1) td:nth-child(6){
+    background-color: #f36363;
+}
+
+table.risktable tr:nth-child(2) td:nth-child(5){
+    background-color: #f36363;
+}
+
+table.risktable tr:nth-child(3) td:nth-child(5){
+    background-color: #f3f363;
+}
+table.risktable tr:nth-child(4) td:nth-child(5){
+    background-color: #f3f363;
+}
+table.risktable tr:nth-child(5) td:nth-child(5){
+    background-color: #63f363;
+}
+
+table.risktable tr:nth-child(1) td:nth-child(7){
+    background-color: #f36363;
+}
+
+table.risktable tr:nth-child(2) td:nth-child(6){
+    background-color: #f36363;
+}
+
+table.risktable tr:nth-child(3) td:nth-child(6){
+    background-color: #f36363;
+}
+table.risktable tr:nth-child(4) td:nth-child(6){
+    background-color: #f3f363;
+}
+table.risktable tr:nth-child(5) td:nth-child(6){
+    background-color: #f3f363;
+}
+
+table.risktable tr:nth-child(6){
+    height: 15px;
+}
+
+table.risktable tr:nth-child(7){
+    height: 15px;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,6 +105,9 @@ release = package.__version__
 # name of a builtin theme or the name of a custom theme in html_theme_path.
 #html_theme = None
 
+html_static_path = ['_static']
+
+html_css_files = ['css/risktable.css', ]
 
 html_theme_options = {
     'logotext1': 'm4opt',  # white,  semi-bold

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,7 +69,8 @@ Project Details
    :maxdepth: 1
 
    npr7150
-
+   risk_assessment
+   
 *****
 Index
 *****

--- a/docs/risk_assessment.rst
+++ b/docs/risk_assessment.rst
@@ -1,0 +1,127 @@
+#################
+Deploying |M4OPT|
+#################
+
+|M4OPT| is an observation planning toolkit. It can be deployed in much the same
+way as one would use the `Astropy` Python library, i.e., ``import m4opt``.
+However, since |M4OPT| will be deployed in planning operations, there are several
+risks that users must be aware of.
+
+1. Lack of Licensing for Gurobi and CPLEX
+
+|M4OPT| utilizes mixed-integer linear programming in order to find and schedule
+optimal observing plans across multiple observatories. It primarily uses
+commercial libraries, specifically Gurobi and CPLEX. These require licenses
+(or connection to a license server) for operation, although academic licenses are also
+available.
+
+|M4OPT| is also planned to support some non-commercial, open-source solvers. However,
+these are not anticipated to perform nearly as well as the commercial
+solvers.
+
+2. Access failures due to lack of internet access
+
+Since |M4OPT| uses the `Astropy.coordinates` module to identify observatory
+and target locations, users should know that `SkyCoord.from_name` and
+`EarthLocation.of_site` both require `an internet connection to access`__
+remote data. If |M4OPT| must be deployed offline, users should consider saving
+a list of `SkyCoord` and `EarthLocation` corresponding to needed locations, `as
+mentioned in the Astropy documentation.`__
+
+__ https://docs.astropy.org/en/stable/coordinates/remote_methods.html
+__ https://docs.astropy.org/en/stable/utils/iers.html#working-offline
+
+Lack of internet access may also affect connection to a license server (see point 1).
+
+Risk Assessment Matrix
+----------------------
+A risk assessment matrix is a tool used in systems engineering to aid in the
+evaluation of project risks. It is used to identify risks, assess their
+frequency (or likelihood), and evaluate their potential impact (e.g., damage
+or service interruption).
+
+In the matrix, the likelihood (on the vertical axis) and
+consequence (on the horizontal axis) are measured from 1 - 5, with 5 being
+the most likely (or most consequential). The cells in the matrix are shaded
+red, yellow, or green: these correspond to high, medium, or low risk.
+
+|M4OPT|'s risk assessment matrix is as follows:
+
+.. table::
+    :class: risktable
+
+    +------------+---+---------+----------+---------+---------+---------+
+    |            | 5 |         |          |         |         |         |
+    +            +---+---------+----------+---------+---------+---------+
+    |            | 4 |         |          |  `2`_   |         |         |
+    +            +---+---------+----------+---------+---------+---------+
+    | Likelihood | 3 |         |          |         |         |         |
+    +            +---+---------+----------+---------+---------+---------+
+    |            | 2 |         |    `1`_  |         |         |         |
+    +            +---+---------+----------+---------+---------+---------+
+    |            | 1 |         |          |         |         |         |
+    +            +---+---------+----------+---------+---------+---------+
+    |            |   |    1    |     2    |    3    |    4    |    5    |
+    +------------+---+---------+----------+---------+---------+---------+
+    |            |   |                 Consequences                     |
+    +------------+---+---------+----------+---------+---------+---------+
+
+List of Risks
+-------------
+
+ID: Example
+^^^^^^^^^^^
+
+Title: Example Title
+
+Affinity: Code, External, Cost, Schedule, Project Requirements, Process, Resources
+
+Description/Status: This is an example risk that is described here.
+
+Mitigation: Plan to mitigate (if any)
+
+Likelihood: Very Low, Low, Moderate, High, Very High
+
+Consequence: Very Low, Low, Moderate, High, Very High
+
+.. _1:
+
+ID: 1
+^^^^^
+
+Title: Lack of Internet Access
+
+Affinity: External
+
+Description/Status: Some `astropy` commands require internet access, namely
+`SkyCoord.from_name` and `EarthLocation.of_site`. Depending on how targets and
+observatory locations will be defined in the user code, this may impact |M4OPT|
+usability.
+
+Mitigation: Raise awareness and document wherever needed.
+
+Likelihood: Low
+
+Consequence: Low
+
+.. _2 :
+
+ID: 2
+^^^^^
+
+Title: Lack of Solver Licensing
+
+Affinity: External
+
+Description/Status: |M4OPT| has dependencies on several mixed-integer linear
+programming solvers, specifically CPLEX and Gurobi. These libraries require
+paid commercial licenses, though academic licenses are available. This will
+impact program performance if user does not have access to
+CPLEX or Gurobi.
+
+Mitigation: Provide interface to open-source libraries. Document differences
+in results and run-time between open-source MILP solvers, CPLEX, and Gurobi.
+
+Likelihood: High
+
+Consequence: Moderate


### PR DESCRIPTION
This is a reopening of #48. The original PR was accidentally closed due to weird consequences after making m4opt public.

As a recap, the new doc page has a layperson description of how to deploy M4OPT and some risks to be aware of. Following this is the risk assessment matrix and descriptions of the risks as required by NPR 7150.2.