### PR TITLE
Work around bug in progressbar2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,7 @@ repos:
         - ligo.skymap >= 2.0.2.dev0
         - numpy >= 2.1.0
         - portion
+        - progressbar2<4.4.3  # FIXME: remove once https://github.com/wolph/python-progressbar/issues/299 is fixed
         - regions
         - satellitetle
         - scipy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "ligo.skymap >= 2.0.2.dev0",
     "numpy >= 2.1.0",
     "portion",
+    "progressbar2<4.4.3",  # FIXME: remove once https://github.com/wolph/python-progressbar/issues/299 is fixed
     "regions",
     "satellitetle",
     "scipy",


### PR DESCRIPTION
Temporarily require progressbar2 < 4.4.3 until
https://github.com/wolph/python-progressbar/issues/299 is fixed.