### PR TITLE
Disable GitHub Actions job for building Sphinx docs

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -62,10 +62,10 @@ jobs:
           #   python: '3.11'
           #   toxenv: py311-test-devdeps
 
-          - name: Test building of Sphinx docs
-            os: ubuntu-latest
-            python: '3.10'
-            toxenv: build_docs
+          # - name: Test building of Sphinx docs
+          #   os: ubuntu-latest
+          #   python: '3.10'
+          #   toxenv: build_docs
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
We build the docs on Readthedocs.