### PR TITLE
Require Python >= 3.11

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -32,39 +32,39 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Python 3.10 with minimal dependencies
+          - name: Python 3.11 with minimal dependencies
             os: ubuntu-latest
-            python: '3.10'
-            toxenv: py310-test
+            python: '3.11'
+            toxenv: py311-test
 
           - name: Python 3.11 with all optional dependencies and coverage checking
             os: ubuntu-latest
             python: '3.11'
             toxenv: py11-test-alldeps-cov
 
-          # - name: OS X - Python 3.10 with all optional dependencies
+          # - name: OS X - Python 3.11 with all optional dependencies
           #   os: macos-latest
-          #   python: '3.10'
-          #   toxenv: py39-test-alldeps
+          #   python: '3.11'
+          #   toxenv: py311-test-alldeps
 
-          # - name: Windows - Python 3.10 with all optional dependencies
+          # - name: Windows - Python 3.11 with all optional dependencies
           #   os: windows-latest
-          #   python: '3.10'
-          #   toxenv: py39-test-alldeps
+          #   python: '3.11'
+          #   toxenv: py311-test-alldeps
 
-          - name: Python 3.10 with oldest supported version of all dependencies
+          - name: Python 3.11 with oldest supported version of all dependencies
             os: ubuntu-20.04
-            python: '3.10'
-            toxenv: py310-test-oldestdeps
+            python: '3.11'
+            toxenv: py311-test-oldestdeps
 
-          # - name: Python 3.10 with latest dev versions of key dependencies
+          # - name: Python 3.11 with latest dev versions of key dependencies
           #   os: ubuntu-latest
           #   python: '3.11'
           #   toxenv: py311-test-devdeps
 
           # - name: Test building of Sphinx docs
           #   os: ubuntu-latest
-          #   python: '3.10'
+          #   python: '3.11'
           #   toxenv: build_docs
 
     steps:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ build:
     - graphviz
   os: ubuntu-24.04
   tools:
-    python: '3.10'
+    python: '3.11'
 
 python:
   install:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,8 @@ import os
 import sys
 from importlib import import_module
 
+import tomllib
+
 try:
     from sphinx_astropy.conf.v2 import *  # noqa
 except ImportError:
@@ -39,12 +41,6 @@ except ImportError:
     sys.exit(1)
 
 # Get configuration information from pyproject.toml
-
-try:
-    import tomllib
-except ImportError:
-    # FIXME: remove when we require Python >= 3.11
-    import tomli as tomllib
 
 with open(os.path.join(os.path.dirname(__file__), "..", "pyproject.toml"), "rb") as f:
     project_metadata = tomllib.load(f)["project"]

--- a/m4opt/constraints/tests/test_body_separation.py
+++ b/m4opt/constraints/tests/test_body_separation.py
@@ -1,4 +1,4 @@
-from warnings import catch_warnings, simplefilter
+from warnings import catch_warnings
 
 import pytest
 from astroplan import MoonSeparationConstraint as AstroplanMoonSeparationConstraint
@@ -30,10 +30,7 @@ def test_astroplan(
     constraint = cls(min_sep)
     astroplan_constraint = astroplan_cls(min_sep)
     result = constraint(observer_location, target_coord, obstime)
-    with catch_warnings():
-        # FIXME: In Python >= 3.11, we can pass the ingnore and category
-        # keyword arguments to catch_warnings and then remove this line.
-        simplefilter(action="ignore", category=NonRotationTransformationWarning)
+    with catch_warnings(action="ignore", category=NonRotationTransformationWarning):
         expected = astroplan_constraint(
             Observer(observer_location), target_coord, obstime
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [{name = "M4OPT Developers", email = "leo.singer@ligo.org"}]
 license = {text = "BSD-3-Clause"}
 description = "Multi-Mission Multi-Messenger Observation Planning Toolkit"
 readme = "README.rst"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "antiprism-python",
     "astropy >= 6.1.5",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py{310,311}-test{,-alldeps,-devdeps}{,-cov}
-    py{310,311}-test-astropy{30,40,lts}
+    py311-test{,-alldeps,-devdeps,oldestdeps}{,-cov}
     build_docs
     linkcheck
     codestyle
@@ -37,18 +36,14 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    astropy30: with astropy 3.0.*
-    astropy40: with astropy 4.0.*
-    astropylts: with the latest astropy LTS
 
 # The following provides some specific pinnings for key packages
 deps =
 
     cov: coverage[toml]
 
-    astropy30: astropy==3.0.*
-    astropy40: astropy==4.0.*
-    astropylts: astropy==4.0.*
+    oldestdeps: ligo.skymap==2.1.0
+    oldestdeps: numpy==2.1.0
 
     devdeps: numpy>=0.0.dev0
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy


### PR DESCRIPTION
This is the minimum version supported by astropy 7.0.0, which was just released.