### PR TITLE
Derive documented parameter types from static typing

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -256,3 +256,9 @@ todo_include_todos = True
 
 # -- Options for the sphinxcontrib.typer extension ----------------------------
 extensions += ["sphinxcontrib.typer"]
+
+
+# -- Merge type annotations with numpydoc parameter docstrings ----------------
+extensions.remove("numpydoc")
+extensions.append("sphinx.ext.napoleon")
+autodoc_typehints = "description"

--- a/m4opt/constraints/_body_separation.py
+++ b/m4opt/constraints/_body_separation.py
@@ -36,7 +36,7 @@ class MoonSeparationConstraint(BodySeparationConstraint):
 
         Parameters
         ----------
-        min : :class:`astropy.units.Quantity`
+        min
             Minimum angular separation from the Moon.
 
         Examples
@@ -65,7 +65,7 @@ class SunSeparationConstraint(BodySeparationConstraint):
 
         Parameters
         ----------
-        min : :class:`astropy.units.Quantity`
+        min
             Minimum angular separation from the Sun.
 
         Examples

--- a/m4opt/constraints/_earth_limb.py
+++ b/m4opt/constraints/_earth_limb.py
@@ -34,7 +34,7 @@ class EarthLimbConstraint(Constraint):
 
     Parameters
     ----------
-    min : :class:`astropy.units.Quantity`
+    min
         Minimum angular separation from the Earth's limb.
 
     Notes

--- a/m4opt/constraints/_galactic.py
+++ b/m4opt/constraints/_galactic.py
@@ -18,7 +18,7 @@ class GalacticLatitudeConstraint(Constraint):
 
     Parameters
     ----------
-    min : :class:`astropy.units.Quantity`
+    min
         Minimum of absolute value of Galactic latitude.
     """
 

--- a/m4opt/fov/_core.py
+++ b/m4opt/fov/_core.py
@@ -122,6 +122,15 @@ def footprint(
     The target coorinate and rotation may be arrays; in that case the return
     value is a Numpy array of regions.
 
+    Parameters
+    ----------
+    region:
+        The shape of the field of view in the standard orientation.
+    target_coord:
+        The position for the center of the field of view.
+    rotation:
+        The rotation of the field of view about its center.
+
     Examples
     --------
 
@@ -264,6 +273,17 @@ def footprint_healpix(
 
     The target coorinate and rotation may be arrays; in that case the return
     value is a Numpy array of arrays of uneven length.
+
+    Parameters
+    ----------
+    hpx:
+        The HEALPix object specifying the ordering and resolution.
+    region:
+        The shape of the field of view in the standard orientation.
+    target_coord:
+        The position for the center of the field of view.
+    rotation:
+        The rotation of the field of view about its center.
 
     Examples
     --------

--- a/m4opt/milp.py
+++ b/m4opt/milp.py
@@ -24,11 +24,11 @@ class Model(_Model):
 
         Parameters
         ----------
-        timelimit : astropy.units.Quantity
+        timelimit
             Maximum solver run time. Default: run until the solver terminates
             naturally due to finding the optimum or proving the problem to be
             infeasible.
-        jobs : int
+        jobs
             Number of threads. If 0, then automatically configure the number of
             threads based on the number of CPUs present.
 
@@ -170,16 +170,12 @@ def add_var_array_method(cls, tp):
 
     Parameters
     ----------
-    shape : int, tuple
+    shape
         The desired shape of the array.
     args, kwargs
         Additional arguments passed to
         :meth:`~docplex.mp.model.Model.{tp}_var_list`, such as lower and upper
         bounds.
-
-    Returns
-    -------
-    numpy.ndarray
 
     Examples
     --------

--- a/m4opt/models/_extinction.py
+++ b/m4opt/models/_extinction.py
@@ -31,6 +31,11 @@ def dust_map():
 def DustExtinction(Ebv: float | None = None):
     """Milky Way dust extinction.
 
+    Parameters
+    ----------
+    Ebv:
+        Reddening color excess, :math:`E(B-V)`.
+
     Notes
     -----
     We use :class:`dust_extinction.parameter_averages.G23` because of its broad

--- a/m4opt/orbit/_core.py
+++ b/m4opt/orbit/_core.py
@@ -19,13 +19,12 @@ class Orbit(ABC):
 
         Parameters
         ----------
-        time : :class:`astropy.time.Time`
+        time
             The time of the observation.
 
         Returns
         -------
-        coord : :class:`astropy.coordinates.SkyCoord`
+        :
             The coordinates of the satellite in the ITRS frame.
-
         """
         raise NotImplementedError

--- a/m4opt/orbit/_tle.py
+++ b/m4opt/orbit/_tle.py
@@ -66,14 +66,14 @@ class TLE(Orbit):
         self._tle = Satrec.twoline2rv(line1, line2)
 
     @classmethod
-    def from_file(cls, name_or_obj: str | IO):
+    def from_file(cls, name_or_obj: str | IO) -> "TLE":
         """Load a TLE from a filename, URL, or file-like object."""
         with get_readable_fileobj(name_or_obj) as f:
             *_, line1, line2 = f.readlines()
         return cls(line1, line2)
 
     @classmethod
-    def from_id(cls, norad_id: int):
+    def from_id(cls, norad_id: int) -> "TLE":
         """Get the latest TLE for a satellite from Celestrak.
 
         Examples

--- a/m4opt/skygrid/_geodesic.py
+++ b/m4opt/skygrid/_geodesic.py
@@ -51,19 +51,19 @@ def geodesic(
 
     Parameters
     ----------
-    area : :class:`astropy.units.Quantity`
+    area
         The average area per tile in any Astropy solid angle units:
         for example, :samp:`10 * astropy.units.deg**2` or
         :samp:`0.1 * astropy.units.steradian`.
-    base : {``'icosahedron'``,  ``'octahedron'``, ``'tetrahedron'``}
+    base
         The base polyhedron of the tesselation.
-    class_ : {``'I'``, ``'II'``, ``'III'``}
+    class_
         The class of the geodesic polyhedron, which constrains the allowed
         values of the number of points. Class III permits the most freedom.
 
     Returns
     -------
-    coords : :class:`astropy.coordinates.SkyCoord`
+    :
         The coordinates of the vertices of the geodesic polyhedron.
 
     References

--- a/m4opt/skygrid/_healpix.py
+++ b/m4opt/skygrid/_healpix.py
@@ -10,14 +10,14 @@ def healpix(area: u.Quantity[u.physical.solid_angle]):
 
     Parameters
     ----------
-    area : :class:`astropy.units.Quantity`
+    area
         The average area per tile in any Astropy solid angle units:
         for example, :samp:`10 * astropy.units.deg**2` or
         :samp:`0.1 * astropy.units.steradian`.
 
     Returns
     -------
-    coords : :class:`astropy.coordinates.SkyCoord`
+    :
         The coordinates of the tiles.
 
     """

--- a/m4opt/skygrid/_sinusoidal.py
+++ b/m4opt/skygrid/_sinusoidal.py
@@ -12,14 +12,14 @@ def sinusoidal(area: u.Quantity[u.physical.solid_angle]):
 
     Parameters
     ----------
-    area : :class:`astropy.units.Quantity`
+    area
         The average area per tile in any Astropy solid angle units:
         for example, :samp:`10 * astropy.units.deg**2` or
         :samp:`0.1 * astropy.units.steradian`.
 
     Returns
     -------
-    coords : :class:`astropy.coordinates.SkyCoord`
+    :
         The coordinates of the tiles.
 
     References

--- a/m4opt/skygrid/_spiral.py
+++ b/m4opt/skygrid/_spiral.py
@@ -13,14 +13,14 @@ def golden_angle_spiral(area: u.Quantity[u.physical.solid_angle]):
 
     Parameters
     ----------
-    area : :class:`astropy.units.Quantity`
+    area
         The average area per tile in any Astropy solid angle units:
         for example, :samp:`10 * astropy.units.deg**2` or
         :samp:`0.1 * astropy.units.steradian`.
 
     Returns
     -------
-    coords : :class:`astropy.coordinates.SkyCoord`
+    :
         The coordinates of the tiles.
 
     References

--- a/m4opt/utils/dynamics/_roll.py
+++ b/m4opt/utils/dynamics/_roll.py
@@ -37,6 +37,20 @@ def nominal_roll(
     This function determines the nominal roll angle for a spacecraft at a given
     location, observing a given target at a given time.
 
+    Parameters
+    ----------
+    observer_location:
+        Location of the spacecraft.
+    target_coord:
+        Orientation of the boresight of the telescope.
+    obstime:
+        The time of the observation.
+
+    Returns
+    -------
+    :
+        The nominal roll angle for the observation.
+
     Examples
     --------
 

--- a/m4opt/utils/dynamics/_slew.py
+++ b/m4opt/utils/dynamics/_slew.py
@@ -94,8 +94,25 @@ class Slew:
         center2: SkyCoord,
         roll1: u.Quantity[u.physical.angle] = 0 * u.rad,
         roll2: u.Quantity[u.physical.angle] = 0 * u.rad,
-    ):
-        """Calculate the time to execute an optimal slew."""
+    ) -> u.Quantity[u.physical.time]:
+        """Calculate the time to execute an optimal slew.
+
+        Parameters
+        ----------
+        center1:
+            Initial boresight position.
+        center2:
+            Final boresight position.
+        roll1:
+            Initial roll angle.
+        roll2:
+            Final roll angle.
+
+        Returns
+        -------
+        :
+            Time to slew between the two orientations.
+        """
         return self._time(
             self.separation(center1, center2, roll1, roll2),
             self.max_angular_velocity,
@@ -112,6 +129,22 @@ class Slew:
     ) -> u.Quantity[u.physical.angle]:
         """
         Determine the smallest angle to slew between two attitudes.
+
+        Parameters
+        ----------
+        center1:
+            Initial boresight position.
+        center2:
+            Final boresight position.
+        roll1:
+            Initial roll angle.
+        roll2:
+            Final roll angle.
+
+        Returns
+        -------
+        :
+            Shortest possible angular separation of the two orientations.
 
         Examples
         --------


### PR DESCRIPTION
Now we don't have to repeat parameter types in both the type annotations and in the docstrings.