### PR TITLE
Disable repr method for dataclasses

### DIFF
--- a/m4opt/missions/_core.py
+++ b/m4opt/missions/_core.py
@@ -10,7 +10,7 @@ from ..orbit import Orbit
 from ..utils.dynamics import Slew
 
 
-@dataclass
+@dataclass(repr=False)
 class Mission:
     """Base class for all missions."""
 

--- a/m4opt/models/_detector.py
+++ b/m4opt/models/_detector.py
@@ -26,7 +26,7 @@ def amplitude_oir_ccd(snr, t, source_eps, sky_eps, dark_eps, rd, npix, gain):
     return 0.5 * snr * (snr + np.sqrt(4 * c2 + np.square(snr))) / c1
 
 
-@dataclass
+@dataclass(repr=False)
 class Detector:
     """Sensitivity calculator: compute SNR for exposure time or vice-versa."""
 


### PR DESCRIPTION
The repr method resulted in extremely long signatures in generated documentation.