### PR TITLE
Remove explicit dependency on hypothesis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "astroplan",
-    "hypothesis",
     "pytest-astropy",
 ]
 docs = [


### PR DESCRIPTION
It isn't necessary, because pytest-astropy depends on it.