### PR TITLE
Bump oldest supported Ubuntu version

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -53,7 +53,7 @@ jobs:
           #   toxenv: py311-test-alldeps
 
           - name: Python 3.11 with oldest supported version of all dependencies
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             python: '3.11'
             toxenv: py311-test-oldestdeps
 


### PR DESCRIPTION
GitHub has dropped support for Ubuntu 20.04.