### PR TITLE
Work around change in click that broke typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "astropy >= 7.0.0",
     "astropy-healpix",
     "astroquery",
+    "click < 8.2.0",  # FIXME: remove when https://github.com/fastapi/typer/discussions/1215 is fixed
     "cplex",
     "docplex",
     "dust-extinction",


### PR DESCRIPTION
This is a temporary workaround for https://github.com/fastapi/typer/discussions/1215.