### PR TITLE
Add collect_dependence function

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -233,6 +233,7 @@ intersphinx_mapping.update(  # noqa: F405
         "ligo.skymap": ("https://lscsoft.docs.ligo.org/ligo.skymap/", None),
         "pip": ("https://pip.pypa.io/en/stable/", None),
         "regions": ("https://astropy-regions.readthedocs.io/en/stable/", None),
+        "sympy": ("https://docs.sympy.org/latest/", None),
         "synphot": ("https://synphot.readthedocs.io/en/stable/", None),
         "userguide": ("https://emfollow.docs.ligo.org/userguide/", None),
     }

--- a/docs/guide/utils.rst
+++ b/docs/guide/utils.rst
@@ -3,6 +3,8 @@ Utilities (`m4opt.utils`)
 *************************
 
 .. automodapi:: m4opt.utils.console
+.. automodapi:: m4opt.utils.functional
 .. automodapi:: m4opt.utils.numpy
 .. automodapi:: m4opt.utils.optimization
 .. automodapi:: m4opt.utils.resource
+.. automodapi:: m4opt.utils.sympy

--- a/m4opt/utils/functional.py
+++ b/m4opt/utils/functional.py
@@ -1,0 +1,25 @@
+"""Functional programming utilities."""
+
+from collections.abc import Callable, Iterable
+from itertools import groupby
+from operator import itemgetter
+from typing import TypeVar
+
+__all__ = ("groupby_unsorted",)
+
+Item = TypeVar("Item")
+Key = TypeVar("Key")
+first = itemgetter(0)
+second = itemgetter(1)
+
+
+def groupby_unsorted(
+    iterable: Iterable[Item], key: Callable[[Item], Key]
+) -> Iterable[tuple[Key, Iterable[Item]]]:
+    """Group items like :obj:`itertools.groupby`, but without requiring the input to be sorted."""
+    return (
+        (key, map(second, values))
+        for key, values in groupby(
+            sorted(((key(item), item) for item in iterable), key=first), key=first
+        )
+    )

--- a/m4opt/utils/sympy.py
+++ b/m4opt/utils/sympy.py
@@ -1,0 +1,40 @@
+"""Symbolic algebra utilities for SymPy."""
+
+from collections.abc import Collection
+
+from sympy import Add, Basic, Expr
+
+from .functional import groupby_unsorted
+
+__all__ = ("collect_dependence",)
+
+
+def collect_dependence(
+    expr: Expr, symbols: Collection[Basic]
+) -> dict[tuple[Basic, ...], Basic]:
+    """
+    Collect terms in an expression that depend on like combinations of symbols.
+
+    Examples
+    --------
+    >>> from m4opt.utils.sympy import collect_dependence
+    >>> from sympy.abc import a, b, c
+    >>> from sympy import sin, Symbol
+    >>> symbols = [a, b, c]
+    >>> expr = a + b + c
+    >>> collect_dependence(expr, symbols)
+    {(c,): c, (b,): b, (a,): a}
+    >>> expr = 42 + a * (sin(a) + sin(b)) + b * (b + c) + c
+    >>> collect_dependence(expr, symbols)
+    {(): 42, (c,): c, (b,): b**2, (b, c): b*c, (a,): a*sin(a), (a, b): a*sin(b)}
+    """
+
+    def depends_on(term: Basic):
+        return tuple(term.has(symbol) for symbol in symbols)
+
+    return {
+        tuple(symbol for keep, symbol in zip(key, symbols) if keep): Add(*terms)
+        for key, terms in groupby_unsorted(
+            expr.expand().as_ordered_terms(), key=depends_on
+        )
+    }


### PR DESCRIPTION
This will help with adding support to m4opt.synphot for spectral models that contain multiple kinds of spatial dependence, e.g. both atmospheric and Galactic extinction.


See #311.