### PR TITLE
Make detector models optional

### DIFF
--- a/m4opt/_cli/animate.py
+++ b/m4opt/_cli/animate.py
@@ -201,6 +201,10 @@ def animate(
             observer_locations = mission.observer_location(time_steps)
 
         if absmag_mean is not None:
+            if mission.detector is None:
+                raise NotImplementedError(
+                    "This mission does not define a detector model"
+                )
             with status("adding exposure time map"):
                 distmod = Distance(skymap_moc.meta["distmean"] * u.Mpc).distmod
                 with observing(

--- a/m4opt/_cli/schedule.py
+++ b/m4opt/_cli/schedule.py
@@ -365,6 +365,8 @@ def schedule(
             pixels_to_fields_map = invert_footprints(footprints, n_pixels)
 
     if adaptive_exptime:
+        if mission.detector is None:
+            raise NotImplementedError("This mission does not define a detector model")
         with status("evaluating exposure time map"):
             if (
                 absmag_stdev is not None

--- a/m4opt/missions/_core.py
+++ b/m4opt/missions/_core.py
@@ -41,7 +41,7 @@ class Mission:
     m4opt.constraints.LogicalNotConstraint
     """
 
-    detector: Detector
+    detector: Detector | None
     """Detector model."""
 
     observer_location: ObserverLocation


### PR DESCRIPTION
This lowers the bar for adding missions, because the background and ETC modeling is usually the hardest part.