### PR TITLE
Fix CPLEX early termination before best bound has been found

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
 Changes
 *******
 
+2.3.1 (2026-01-23)
+==================
+
+- Fix an issue where MILP optimization could terminate early before CPLEX had
+  found a best bound. This was prone to happen after MIP restarts.
+
 2.3.0 (2026-01-22)
 ==================
 

--- a/m4opt/milp.py
+++ b/m4opt/milp.py
@@ -29,7 +29,9 @@ class LowerCutoffCallback:
 
     def invoke(self, context: cplex.callbacks.Context):
         best_bound = context.get_double_info(cplex.callbacks.CallbackInfo.best_bound)
-        if best_bound <= self._cutoff:
+        # Note that CPLEX indicates that it has not yet found a best bound by
+        # setting this to a large negative value.
+        if -cplex.infinity < best_bound <= self._cutoff:
             print(
                 f"giving up because best bound ({best_bound}) <= cutoff ({self._cutoff})"
             )


### PR DESCRIPTION
This was prone to happen after MIP restarts.