### PR TITLE
Fix tox alldeps environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ deps =
 # The following indicates which extras_require from pyproject.toml will be installed
 extras =
     test
-    alldeps: all
+    alldeps: docs
 
 commands =
     pip freeze


### PR DESCRIPTION
Tox no longer seems like `all` as an extra specifier.