### PR TITLE
Don't let codespell automatically fix up code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,5 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
-        args: ["--write-changes"]
         additional_dependencies:
           - tomli


### PR DESCRIPTION
Automatic spell check is much more likely to accidentally make unwanted functional changes to code, especially when short variable names are misinterpreted as missspelled English words. It's safer to display the spell check errors and let the contributor deal with them manually.