### PR TITLE
Add constraints to enforce visiting all fields before revisiting

### DIFF
--- a/docs/design/milp.rst
+++ b/docs/design/milp.rst
@@ -95,10 +95,10 @@ Constraints
     :label: fixed-exptime-constraint-no-overlap
 
     \begin{eqnarray}
-    \forall j \neq j,\; k :\quad \left|t_{jk} - t_{j^\prime k}\right|  \geq \left(\sigma_{jj^\prime} + \epsilon\right) \left( r_j + r_{j^\prime} - 1\right) \\
-    \forall j \neq j,\; k > 1:\quad t_{jk} - t_{j^\prime , k - 1}  \geq \left(\sigma_{jj^\prime} + \epsilon\right) \left( r_j + r_{j^\prime} - 1\right)
+    \forall j^\prime \neq j,\; k :\quad \left|t_{jk} - t_{j^\prime k}\right|  \geq \left(\sigma_{jj^\prime} + \epsilon\right) \left( r_j + r_{j^\prime} - 1\right) \\
+    \forall j^\prime \neq j,\; k > 1 :\quad t_{jk} - t_{j^\prime , k - 1}  \geq \left(\sigma_{jj^\prime} + \epsilon\right) \left( r_j + r_{j^\prime} - 1\right)
     \end{eqnarray}
-    
+
 **Field of regard.** An observation of a reference field can only occur while the coordinates of the reference field are within the field of regard.
 
 For fields that have one observable segment (:math:`{n_M}_j = 1`), this constraint is simply an inequality:

--- a/docs/design/milp.rst
+++ b/docs/design/milp.rst
@@ -207,10 +207,8 @@ For fields that have more than one observable segment:
 .. math::
     :label: variable-exptime-constraint-for-many
 
-    \begin{eqnarray}
     \forall j ,\; k \;, m \mid {n_M}_j > 1 :\quad s_{jkm} &=& 1 \;\Rightarrow\; \alpha_{jm} + e_j / 2 \leq t_{jk} \leq \omega_{jm} - e_j / 2, \\
     \sum_m s_{jkm} &\geq& 1
-    \end{eqnarray}
 
 Additional cuts
 """""""""""""""
@@ -220,10 +218,8 @@ Additional cuts
 .. math::
     :label: variable-exptime-cut-total-time
 
-    \begin{eqnarray}
     \sum_{j \in J} r_j &\leq& \frac{\delta - \beta}{\epsilon_\mathrm{min} n_K} \\
     \sum_{j \in J} e_j &\leq& \frac{\delta - \beta}{n_K}
-    \end{eqnarray}
 
 Objective
 """""""""

--- a/docs/design/milp.rst
+++ b/docs/design/milp.rst
@@ -94,10 +94,9 @@ Constraints
 .. math::
     :label: fixed-exptime-constraint-no-overlap
 
-    \begin{eqnarray}
-    \forall j^\prime \neq j,\; k :\quad \left|t_{jk} - t_{j^\prime k}\right|  \geq \left(\sigma_{jj^\prime} + \epsilon\right) \left( r_j + r_{j^\prime} - 1\right) \\
+    \forall j^\prime \neq j,\; k :\quad \left|t_{jk} - t_{j^\prime k}\right|  \geq \left(\sigma_{jj^\prime} + \epsilon\right) \left( r_j + r_{j^\prime} - 1\right) 
+
     \forall j^\prime \neq j,\; k > 1 :\quad t_{jk} - t_{j^\prime , k - 1}  \geq \left(\sigma_{jj^\prime} + \epsilon\right) \left( r_j + r_{j^\prime} - 1\right)
-    \end{eqnarray}
 
 **Field of regard.** An observation of a reference field can only occur while the coordinates of the reference field are within the field of regard.
 
@@ -113,10 +112,9 @@ For fields that have more than one observable segment (:math:`{n_M}_j > 1`), we 
 .. math::
     :label: fixed-exptime-constraint-for-many
 
-    \begin{eqnarray}
-    \forall j ,\; k \;, m \mid {n_M}_j > 1 :\quad s_{jkm} &=& 1 \;\Rightarrow\; \alpha_{jm} + \epsilon / 2 \leq t_{jk} \leq \omega_{jm} - \epsilon / 2, \\
+    \forall j ,\; k \;, m \mid {n_M}_j > 1 :\quad s_{jkm} &=& 1 \;\Rightarrow\; \alpha_{jm} + \epsilon / 2 \leq t_{jk} \leq \omega_{jm} - \epsilon / 2, 
+
     \sum_m s_{jkm} &\geq& 1
-    \end{eqnarray}
 
 Cuts
 """"
@@ -207,8 +205,10 @@ For fields that have more than one observable segment:
 .. math::
     :label: variable-exptime-constraint-for-many
 
+    \begin{eqnarray}
     \forall j ,\; k \;, m \mid {n_M}_j > 1 :\quad s_{jkm} &=& 1 \;\Rightarrow\; \alpha_{jm} + e_j / 2 \leq t_{jk} \leq \omega_{jm} - e_j / 2, \\
     \sum_m s_{jkm} &\geq& 1
+    \end{eqnarray}
 
 Additional cuts
 """""""""""""""
@@ -218,8 +218,10 @@ Additional cuts
 .. math::
     :label: variable-exptime-cut-total-time
 
+    \begin{eqnarray}
     \sum_{j \in J} r_j &\leq& \frac{\delta - \beta}{\epsilon_\mathrm{min} n_K} \\
     \sum_{j \in J} e_j &\leq& \frac{\delta - \beta}{n_K}
+    \end{eqnarray}
 
 Objective
 """""""""

--- a/docs/design/milp.rst
+++ b/docs/design/milp.rst
@@ -94,7 +94,7 @@ Constraints
 .. math::
     :label: fixed-exptime-constraint-no-overlap
 
-    \forall j^\prime \neq j,\; k :\quad \left|t_{jk} - t_{j^\prime k}\right|  \geq \left(\sigma_{jj^\prime} + \epsilon\right) \left( r_j + r_{j^\prime} - 1\right) 
+    \forall j^\prime \neq j,\; k :\quad \left|t_{jk} - t_{j^\prime k}\right|  \geq \left(\sigma_{jj^\prime} + \epsilon\right) \left( r_j + r_{j^\prime} - 1\right)
 
     \forall j^\prime \neq j,\; k > 1 :\quad t_{jk} - t_{j^\prime , k - 1}  \geq \left(\sigma_{jj^\prime} + \epsilon\right) \left( r_j + r_{j^\prime} - 1\right)
 
@@ -112,7 +112,7 @@ For fields that have more than one observable segment (:math:`{n_M}_j > 1`), we 
 .. math::
     :label: fixed-exptime-constraint-for-many
 
-    \forall j ,\; k \;, m \mid {n_M}_j > 1 :\quad s_{jkm} &=& 1 \;\Rightarrow\; \alpha_{jm} + \epsilon / 2 \leq t_{jk} \leq \omega_{jm} - \epsilon / 2, 
+    \forall j ,\; k \;, m \mid {n_M}_j > 1 :\quad s_{jkm} &=& 1 \;\Rightarrow\; \alpha_{jm} + \epsilon / 2 \leq t_{jk} \leq \omega_{jm} - \epsilon / 2,
 
     \sum_m s_{jkm} &\geq& 1
 

--- a/docs/design/milp.rst
+++ b/docs/design/milp.rst
@@ -89,13 +89,16 @@ Constraints
 
     \forall k > 1 ,\; j :\quad t_{jk} - t_{j,k-1} \geq (\epsilon + \gamma) r_j
 
-**No overlap.** Observations cannot overlap in time; they must be separated by at least the exposure time plus the slew time.
+**No overlap.** Observations cannot overlap in time; they must be separated by at least the exposure time plus the slew time. Additionally, all fields must be visited k - 1 times before any field is visited k times.
 
 .. math::
     :label: fixed-exptime-constraint-no-overlap
 
-    \forall j^\prime > j,\; k ,\; k^\prime :\quad \left|t_{jk} - t_{j^\prime k^\prime}\right|  \geq \left(\sigma_{jj^\prime} + \epsilon\right) \left( r_j + r_{j^\prime} - 1\right)
-
+    \begin{eqnarray}
+    \forall j \neq j,\; k :\quad \left|t_{jk} - t_{j^\prime k}\right|  \geq \left(\sigma_{jj^\prime} + \epsilon\right) \left( r_j + r_{j^\prime} - 1\right) \\
+    \forall j \neq j,\; k > 1:\quad t_{jk} - t_{j^\prime , k - 1}  \geq \left(\sigma_{jj^\prime} + \epsilon\right) \left( r_j + r_{j^\prime} - 1\right)
+    \end{eqnarray}
+    
 **Field of regard.** An observation of a reference field can only occur while the coordinates of the reference field are within the field of regard.
 
 For fields that have one observable segment (:math:`{n_M}_j = 1`), this constraint is simply an inequality:

--- a/m4opt/_cli/schedule.py
+++ b/m4opt/_cli/schedule.py
@@ -517,17 +517,29 @@ def schedule(
                     rhs = 0.5 * (
                         exptime_field_vars[slew_i] + exptime_field_vars[slew_j]
                     ) + slew_time_s * (field_vars[slew_i] + field_vars[slew_j] - 1)
+                    model.add_constraints_(
+                        model.abs(
+                            time_field_visit_vars[slew_i, p[:, np.newaxis]]
+                            - time_field_visit_vars[slew_j, q[:, np.newaxis]]
+                        )
+                        >= rhs
+                    )
                 else:
                     rhs = (slew_time_s + exptime_min_s) * (
                         field_vars[slew_i] + field_vars[slew_j] - 1
                     )
-                model.add_constraints_(
-                    model.abs(
-                        time_field_visit_vars[slew_i, p[:, np.newaxis]]
-                        - time_field_visit_vars[slew_j, q[:, np.newaxis]]
+                    model.add_constraints_(
+                        model.abs(
+                            time_field_visit_vars[slew_i, :]
+                            - time_field_visit_vars[slew_j, :]
+                        )
+                        >= rhs
                     )
-                    >= rhs
-                )
+                    model.add_constraints_(
+                        time_field_visit_vars[slew_i, 1:]
+                        - time_field_visit_vars[slew_j, :-1]
+                        >= rhs
+                    )
 
             if adaptive_exptime:
                 with status("adding exposure time constraints"):


### PR DESCRIPTION
This enforces every field being visited k - 1 times before any field being visited k times (hopefully). This assumes scalar exposure times and delays as described by Equations 3 and 4 [here](https://www.overleaf.com/read/jrmmrbvfxzft#e17595). 

Once this is edited and merged, I can open PRs to account for sequences of exposure times and delays as described by Equations 5, 6, and 7 in the linked document. 