### PR TITLE
Fix broken readthedocs build due to API changes in Typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "spiceypy",
     "sympy",
     "synphot",
-    "typer >= 0.26.0",
+    "typer >= 0.26.0, < 0.26.8",  # https://github.com/sphinx-contrib/typer/issues/68
     "xdg-base-dirs",
 ]
 classifiers = [


### PR DESCRIPTION
See https://github.com/sphinx-contrib/typer/issues/68, https://github.com/fastapi/typer/pull/1410.