### PR TITLE
Add helioecliptic longitude constraint

### DIFF
--- a/m4opt/constraints/__init__.py
+++ b/m4opt/constraints/__init__.py
@@ -9,6 +9,7 @@ from ._positional import (
     AltitudeConstraint,
     AzimuthConstraint,
     DeclinationConstraint,
+    HelioeclipticLongitudeConstraint,
     HourAngleConstraint,
     RightAscensionConstraint,
 )
@@ -23,6 +24,7 @@ __all__ = (
     "DeclinationConstraint",
     "EarthLimbConstraint",
     "GalacticLatitudeConstraint",
+    "HelioeclipticLongitudeConstraint",
     "HourAngleConstraint",
     "LogicalAndConstraint",
     "LogicalNotConstraint",

--- a/m4opt/constraints/_positional.py
+++ b/m4opt/constraints/_positional.py
@@ -3,15 +3,18 @@
 from abc import abstractmethod
 from typing import override
 
+import numpy as np
 from astropy import units as u
 from astropy.coordinates import (
     ICRS,
     AltAz,
     Angle,
     EarthLocation,
+    GeocentricTrueEcliptic,
     HADec,
     SkyCoord,
     UnitSphericalRepresentation,
+    get_sun,
 )
 from astropy.time import Time
 
@@ -63,6 +66,14 @@ class HADecConstraint(AngleConstraint):
     @override
     def _frame(self, observer_location, obstime):
         return HADec(obstime=obstime, location=observer_location)
+
+
+class GeocentricTrueEclipticConstraint(AngleConstraint):
+    """Constrain an angle in the :class:`~astropy.coordinates.GeocentricTrueEclipticConstraint` frame."""
+
+    @override
+    def _frame(self, observer_location, obstime):
+        return GeocentricTrueEcliptic(obstime=obstime)
 
 
 class ICRSConstraint(AngleConstraint):
@@ -158,3 +169,30 @@ class HourAngleConstraint(LongitudeConstraint, HADecConstraint):
     --------
     RightAscensionConstraint
     """
+
+
+class HelioeclipticLongitudeConstraint(GeocentricTrueEclipticConstraint):
+    """Constraint the helioecliptic longitude of the target.
+
+    This places a constraint on the absolute value, between 0° and 180°, of the
+    ecliptic longitude of the target minus the ecliptic longitude of the sun.
+
+    Warnings
+    --------
+    This model should only be used for observers near Earth --- in Earth orbit,
+    as Hubble is, or on the Earth, or even on the Moon or in cislunar space. It
+    should NOT be used for observers in orbits around other planets, or in
+    distant solar orbits, or at Earth-Sun Lagrange points.
+    """
+
+    @override
+    def _get_angle(self, observer_location, target_coord, obstime):
+        frame = self._frame(observer_location, obstime)
+        sun = get_sun(obstime)
+        lon = (
+            target_coord.transform_to(frame)
+            .represent_as(UnitSphericalRepresentation)
+            .lon
+        )
+        lon0 = sun.transform_to(frame).represent_as(UnitSphericalRepresentation).lon
+        return np.abs((lon - lon0).wrap_at(180 * u.deg))

--- a/m4opt/constraints/tests/test_positional.py
+++ b/m4opt/constraints/tests/test_positional.py
@@ -1,5 +1,6 @@
+import numpy as np
 from astropy import units as u
-from astropy.coordinates import AltAz, Angle, HADec
+from astropy.coordinates import AltAz, Angle, GeocentricTrueEcliptic, HADec, get_sun
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
@@ -12,6 +13,7 @@ from .._positional import (
     AltitudeConstraint,
     AzimuthConstraint,
     DeclinationConstraint,
+    HelioeclipticLongitudeConstraint,
     HourAngleConstraint,
     RightAscensionConstraint,
 )
@@ -67,3 +69,11 @@ def test_positional(observer_location, target_coord, obstime, lon_bounds, lat_bo
     )
     lon = frame.ha.wrap_at(lon_hi)
     assert (lon_lo <= lon) & (lon <= lon_hi) == HourAngleConstraint(*lon_bounds)(*args)
+
+    frame = target_coord.transform_to(GeocentricTrueEcliptic(obstime=obstime))
+    lon_target = frame.lon
+    lon0 = get_sun(obstime).transform_to(frame).lon
+    lon = np.abs((lon_target - lon0).wrap_at(180 * u.deg))
+    assert (lon_lo <= lon) & (lon <= lon_hi) == HelioeclipticLongitudeConstraint(
+        *lon_bounds
+    )(*args)


### PR DESCRIPTION
UVEX is evaluating a possible survey policy of scheduling survey fields at times near lowest zodiacal light conditions. Zodiacal light is primarily a function of ecliptic latitude and of the difference in ecliptic longitude between the target and the sun. For fixed stars, the former does not change significantly over human timescales, whereas the latter varies through a full cycle over the course of the year.