### PR TITLE
Change observer_location class for ground observatories in the ECSV file

### DIFF
--- a/m4opt/_cli/schedule.py
+++ b/m4opt/_cli/schedule.py
@@ -6,7 +6,7 @@ import numpy as np
 import synphot
 import typer
 from astropy import units as u
-from astropy.coordinates import ICRS, Distance, SkyCoord
+from astropy.coordinates import ICRS, Distance, SkyCoord, EarthLocation
 from astropy.table import QTable, vstack
 from astropy.time import Time
 from astropy_healpix import HEALPix
@@ -696,7 +696,9 @@ def schedule(
                 name="observer_location",
             )
             table["observer_location"].info.description = "Position of the spacecraft"
-
+            if isinstance(mission.observer_location, EarthFixedObserverLocation):
+                table["observer_location"].__class__ = EarthLocation
+                
             # Add slew segments to table.
             if len(table) > 0:
                 nrows = len(table) - 1

--- a/m4opt/_cli/schedule.py
+++ b/m4opt/_cli/schedule.py
@@ -6,7 +6,7 @@ import numpy as np
 import synphot
 import typer
 from astropy import units as u
-from astropy.coordinates import ICRS, Distance, SkyCoord, EarthLocation
+from astropy.coordinates import ICRS, Distance, EarthLocation, SkyCoord
 from astropy.table import QTable, vstack
 from astropy.time import Time
 from astropy_healpix import HEALPix
@@ -698,7 +698,7 @@ def schedule(
             table["observer_location"].info.description = "Position of the spacecraft"
             if isinstance(mission.observer_location, EarthFixedObserverLocation):
                 table["observer_location"].__class__ = EarthLocation
-                
+
             # Add slew segments to table.
             if len(table) > 0:
                 nrows = len(table) - 1


### PR DESCRIPTION
This fixes #514 to make the ECSV file readable for ground-based missions by updating the class of `observer_location` in the ECSV header to be `astropy.coordinates.earth.EarthLocation` instead of `m4opt.observer._earth_fixed.EarthFixedObserverLocation`. 

This does not affect the actual scheduling or solution, just the ECSV header. 