### PR TITLE
EarthFixedObserverLocation shouldn't subclass of EarthLocation

### DIFF
--- a/m4opt/missions/_rubin/__init__.py
+++ b/m4opt/missions/_rubin/__init__.py
@@ -3,7 +3,7 @@ from importlib import resources
 import numpy as np
 import yaml
 from astropy import units as u
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.table import Table
 from regions import RectangleSkyRegion, Regions
 
@@ -51,7 +51,7 @@ rubin = Mission(
         & AtNightConstraint.twilight_astronomical()
         & MoonSeparationConstraint(30 * u.deg)
     ),
-    observer_location=EarthFixedObserverLocation.of_site("LSST"),
+    observer_location=EarthFixedObserverLocation(EarthLocation.of_site("LSST")),
     # Sky grid optimized for LSST’s large field of view.
     skygrid=skygrid.geodesic(3.5 * u.deg**2, class_="III", base="icosahedron"),
     # FIXME: The Telescope Mount Assembly is faster than the dome for long slews.

--- a/m4opt/missions/_ztf/__init__.py
+++ b/m4opt/missions/_ztf/__init__.py
@@ -2,7 +2,7 @@ from importlib import resources
 
 import numpy as np
 from astropy import units as u
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.table import Table
 from regions import PolygonSkyRegion, Regions
 
@@ -98,7 +98,7 @@ ztf = Mission(
         )
         & DeclinationConstraint(-90 * u.deg, 87.5 * u.deg)
     ),
-    observer_location=EarthFixedObserverLocation.of_site("Palomar"),
+    observer_location=EarthFixedObserverLocation(EarthLocation.of_site("Palomar")),
     skygrid=_read_skygrid(),
     # From Section 4.2:
     #

--- a/m4opt/observer/_earth_fixed.py
+++ b/m4opt/observer/_earth_fixed.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import override
 
 import numpy as np
@@ -6,16 +7,21 @@ from astropy.coordinates import EarthLocation
 from ._core import ObserverLocation
 
 
-class EarthFixedObserverLocation(ObserverLocation, EarthLocation):
+@dataclass
+class EarthFixedObserverLocation(ObserverLocation):
     """An observer at a fixed location on the surface of the Earth.
 
+    >>> from astropy.coordinates import EarthLocation
     >>> from astropy.time import Time
     >>> from m4opt.observer import EarthFixedObserverLocation
-    >>> observer = EarthFixedObserverLocation.of_site("LSST")
+    >>> observer = EarthFixedObserverLocation(EarthLocation.of_site("LSST"))
     >>> observer(Time.now())
-    <EarthFixedObserverLocation (1818939.00669747, -5208471.0353078, -3195171.4154367) m>
+    <EarthLocation (1818939.00669747, -5208471.0353078, -3195171.4154367) m>
     """
+
+    earth_location: EarthLocation
+    """The time-independent Earth-fixed location of the observer."""
 
     @override
     def __call__(self, time):
-        return np.broadcast_to(self, time.shape, subok=True)
+        return np.broadcast_to(self.earth_location, time.shape, subok=True)


### PR DESCRIPTION
A "has-a" relationship is more appropriate than an "is-a" relationship here.

Fixes #514. Fixes #526.