### PR TITLE
Fix ruff errors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ rst_epilog += r"""
 # This does not *have* to match the package name, but typically does
 project = project_metadata["name"]
 author = project_metadata["authors"][0]["name"]
-copyright = f"{datetime.datetime.now().year}, {author}"
+copyright = f"{datetime.datetime.now(datetime.UTC).year}, {author}"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -280,7 +280,7 @@ bibtex_default_style = "short_alpha"
 class CustomHyperlinkAvailabilityChecker(linkcheck.HyperlinkAvailabilityChecker):
     """Ignore 403 errors from certain servers."""
 
-    allow_403 = ["https://doi.org/"]
+    allow_403 = ("https://doi.org/",)
 
     def check(self, hyperlinks):
         for result in super().check(hyperlinks):

--- a/m4opt/_cli/animate.py
+++ b/m4opt/_cli/animate.py
@@ -151,9 +151,9 @@ def animate(
                     for ax, transform in zip(ax_maps, transforms)
                 ]
                 for kwargs in [
-                    dict(marker=earth, mec="black"),
-                    dict(marker=sun, mec="black"),
-                    dict(marker=moon(-115), mfc="black", mec="none"),
+                    {"marker": earth, "mec": "black"},
+                    {"marker": sun, "mec": "black"},
+                    {"marker": moon(-115), "mfc": "black", "mec": "none"},
                 ]
             ]
             fig.legend(

--- a/m4opt/synphot/extinction/_dust.py
+++ b/m4opt/synphot/extinction/_dust.py
@@ -7,6 +7,12 @@ from astropy.modeling import Model, Parameter
 from astropy.utils.data import download_file
 from dust_extinction.parameter_averages import G23
 
+try:
+    frozendict  # noqa: B018
+except NameError:
+    # FIXME: remove once we depend on Python >= 3.15
+    from frozendict import frozendict
+
 with warnings.catch_warnings():
     # Suppress configuration file warnings from the dustmaps package.
     # We are not using the configuration file.
@@ -73,9 +79,9 @@ def DustExtinction(Ebv: float | None = None):
 class DustExtinctionBase(Model):
     n_inputs = 1
     n_outputs = 1
-    input_units = {"x": BaseSpectrum._internal_wave_unit}
-    return_units = {"y": u.dimensionless_unscaled}
-    input_units_equivalencies = {"x": u.spectral()}
+    input_units = frozendict(x=BaseSpectrum._internal_wave_unit)
+    return_units = frozendict(y=u.dimensionless_unscaled)
+    input_units_equivalencies = frozendict(x=u.spectral())
 
     # argh, why!! synphot.BaseSpectrum passes unitless quantities to the underlying model.
     _input_units_allow_dimensionless = True

--- a/m4opt/tests/test_milp.py
+++ b/m4opt/tests/test_milp.py
@@ -108,7 +108,9 @@ def test_cplex_operators(tp, rhs_shape, expr):
     """Test adding constraints by broadcasting variables."""
     m = Model()
     add_vars = getattr(m, f"{tp}_vars")
-    constraint = eval(expr, None, dict(m=m, x=add_vars((3, 2)), y=add_vars(rhs_shape)))
+    constraint = eval(
+        expr, None, {"m": m, "x": add_vars((3, 2)), "y": add_vars(rhs_shape)}
+    )
     assert isinstance(constraint, VariableArray)
     m.add_constraints_(constraint)
 

--- a/m4opt/utils/functional.py
+++ b/m4opt/utils/functional.py
@@ -13,7 +13,7 @@ first = itemgetter(0)
 second = itemgetter(1)
 
 
-def groupby_unsorted(
+def groupby_unsorted[Item, Key](
     iterable: Iterable[Item], key: Callable[[Item], Key]
 ) -> Iterable[tuple[Key, Iterable[Item]]]:
     """Group items like :obj:`itertools.groupby`, but without requiring the input to be sorted."""

--- a/m4opt/utils/tests/test_optimization.py
+++ b/m4opt/utils/tests/test_optimization.py
@@ -47,7 +47,7 @@ def test_partition_graph():
 
 def test_partition_graph_color():
     n = 5
-    kwargs = dict(n=n, seed=42)
+    kwargs = {"n": n, "seed": 42}
     graph = nx.convert_node_labels_to_integers(nx.triangular_lattice_graph(10, 20))
     adjacency = nx.to_numpy_array(graph)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "docplex",
     "dust-extinction >= 1.7",
     "dustmaps",
+    "frozendict; python_version < '3.15'",
     "ligo.skymap >= 2.5.4",
     "networkx",
     "numpy >= 2.5.0",  # https://github.com/numpy/numpy/pull/30870


### PR DESCRIPTION
A recent ruff update introduced some new checks. Fix the following ruff errors.

```
$ pre-commit run --all-files
check for case conflicts.................................................Passed
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
check for broken symlinks................................................Passed
check toml...............................................................Passed
check xml............................................(no files to check)Skipped
check yaml...............................................................Passed
detect private key.......................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff check...............................................................Failed
- hook id: ruff-check
- exit code: 1

DTZ005 `datetime.datetime.now()` called without a `tz` argument
  --> docs/conf.py:77:16
   |
75 | project = project_metadata["name"]
76 | author = project_metadata["authors"][0]["name"]
77 | copyright = f"{datetime.datetime.now().year}, {author}"
   |                ^^^^^^^^^^^^^^^^^^^^^^^
78 |
79 | # The version info for the project you're documenting, acts as replacement for
   |
help: Pass a `datetime.timezone` object to the `tz` parameter

RUF012 Mutable default value for class attribute
   --> docs/conf.py:283:17
    |
281 |     """Ignore 403 errors from certain servers."""
282 |
283 |     allow_403 = ["https://doi.org/"]
    |                 ^^^^^^^^^^^^^^^^^^^^
284 |
285 |     def check(self, hyperlinks):
    |
help: Consider initializing in `__init__` or annotating with `typing.ClassVar`

C408 Unnecessary `dict()` call (rewrite as a literal)
   --> m4opt/_cli/animate.py:154:21
    |
152 |                 ]
153 |                 for kwargs in [
154 |                     dict(marker=earth, mec="black"),
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
155 |                     dict(marker=sun, mec="black"),
156 |                     dict(marker=moon(-115), mfc="black", mec="none"),
    |
help: Rewrite as a literal

C408 Unnecessary `dict()` call (rewrite as a literal)
   --> m4opt/_cli/animate.py:155:21
    |
153 |                 for kwargs in [
154 |                     dict(marker=earth, mec="black"),
155 |                     dict(marker=sun, mec="black"),
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
156 |                     dict(marker=moon(-115), mfc="black", mec="none"),
157 |                 ]
    |
help: Rewrite as a literal

C408 Unnecessary `dict()` call (rewrite as a literal)
   --> m4opt/_cli/animate.py:156:21
    |
154 |                     dict(marker=earth, mec="black"),
155 |                     dict(marker=sun, mec="black"),
156 |                     dict(marker=moon(-115), mfc="black", mec="none"),
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
157 |                 ]
158 |             ]
    |
help: Rewrite as a literal

RUF012 Mutable default value for class attribute
  --> m4opt/synphot/extinction/_dust.py:76:19
   |
74 |     n_inputs = 1
75 |     n_outputs = 1
76 |     input_units = {"x": BaseSpectrum._internal_wave_unit}
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
77 |     return_units = {"y": u.dimensionless_unscaled}
78 |     input_units_equivalencies = {"x": u.spectral()}
   |
help: Consider initializing in `__init__` or annotating with `typing.ClassVar`

RUF012 Mutable default value for class attribute
  --> m4opt/synphot/extinction/_dust.py:77:20
   |
75 |     n_outputs = 1
76 |     input_units = {"x": BaseSpectrum._internal_wave_unit}
77 |     return_units = {"y": u.dimensionless_unscaled}
   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
78 |     input_units_equivalencies = {"x": u.spectral()}
   |
help: Consider initializing in `__init__` or annotating with `typing.ClassVar`

RUF012 Mutable default value for class attribute
  --> m4opt/synphot/extinction/_dust.py:78:33
   |
76 |     input_units = {"x": BaseSpectrum._internal_wave_unit}
77 |     return_units = {"y": u.dimensionless_unscaled}
78 |     input_units_equivalencies = {"x": u.spectral()}
   |                                 ^^^^^^^^^^^^^^^^^^^
79 |
80 |     # argh, why!! synphot.BaseSpectrum passes unitless quantities to the underlying model.
   |
help: Consider initializing in `__init__` or annotating with `typing.ClassVar`

C408 Unnecessary `dict()` call (rewrite as a literal)
   --> m4opt/tests/test_milp.py:111:35
    |
109 |     m = Model()
110 |     add_vars = getattr(m, f"{tp}_vars")
111 |     constraint = eval(expr, None, dict(m=m, x=add_vars((3, 2)), y=add_vars(rhs_shape)))
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
112 |     assert isinstance(constraint, VariableArray)
113 |     m.add_constraints_(constraint)
    |
help: Rewrite as a literal

UP047 Generic function `groupby_unsorted` should use type parameters
  --> m4opt/utils/functional.py:16:5
   |
16 |   def groupby_unsorted(
   |  _____^
17 | |     iterable: Iterable[Item], key: Callable[[Item], Key]
18 | | ) -> Iterable[tuple[Key, Iterable[Item]]]:
   | |_^
19 |       """Group items like :obj:`itertools.groupby`, but without requiring the input to be sorted."""
20 |       return (
   |
help: Use type parameters

C408 Unnecessary `dict()` call (rewrite as a literal)
  --> m4opt/utils/tests/test_optimization.py:50:14
   |
48 | def test_partition_graph_color():
49 |     n = 5
50 |     kwargs = dict(n=n, seed=42)
   |              ^^^^^^^^^^^^^^^^^^
51 |     graph = nx.convert_node_labels_to_integers(nx.triangular_lattice_graph(10, 20))
52 |     adjacency = nx.to_numpy_array(graph)
   |
help: Rewrite as a literal

Found 11 errors.
No fixes available (6 hidden fixes can be enabled with the `--unsafe-fixes` option).

ruff format..............................................................Passed
codespell................................................................Passed
```