### PR TITLE
Skip doctest that contacts Celestrak

### DIFF
--- a/m4opt/observer/_tle.py
+++ b/m4opt/observer/_tle.py
@@ -71,7 +71,7 @@ class TleObserverLocation(ObserverLocation):
         Look up the latest TLE for the Fermi Gamma-Ray Space Telescope.
 
         >>> from m4opt.observer import TleObserverLocation
-        >>> tle = TleObserverLocation.from_id(33053)
+        >>> tle = TleObserverLocation.from_id(33053)  # doctest: +SKIP
         """
         *_, line1, line2 = fetch_tle_from_celestrak(norad_id)
         return cls(line1, line2)


### PR DESCRIPTION
Celestrak has severe rate limits and a draconian policy around enforcing them. The tests that depend on Celestrak are flaky. Disable them for now.

This is not a great loss right now, because due to the recent exhaustion of 5-digit catalog numbers, we need to migrate from TLEs to a new format (see https://celestrak.org/NORAD/documentation/gp-data-formats.php).