### PR TITLE
Fix incorrectly running every test twice

### DIFF
--- a/src/m4opt/tests/plugins/problem_size_limits.py
+++ b/src/m4opt/tests/plugins/problem_size_limits.py
@@ -2,9 +2,11 @@ import pytest
 from docplex.mp.utils import DOcplexLimitsExceeded
 
 
+@pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item):
     """Skip tests that exceed the Gurobi or CPLEX problem size."""
-    try:
-        item.runtest()
-    except DOcplexLimitsExceeded:
+    outcome = yield
+    if outcome.excinfo is not None and issubclass(
+        outcome.excinfo[0], DOcplexLimitsExceeded
+    ):
         pytest.skip("requires full version of CPLEX")


### PR DESCRIPTION
This fix was identified using gpt-5.3-codex via Continue.