### PR TITLE
Raise NotImplementedError in all placeholder abstract methods

### DIFF
--- a/src/m4opt/constraints/_core.py
+++ b/src/m4opt/constraints/_core.py
@@ -14,6 +14,7 @@ class Constraint(ABC):
         self, observer_location: EarthLocation, target_coord: SkyCoord, obstime: Time
     ) -> npt.NDArray[np.bool_]:
         """Evaluate the constraint at a given observer location, target position, and time."""
+        raise NotImplementedError
 
     def __and__(self, rhs):
         from ._logical import LogicalAndConstraint

--- a/src/m4opt/constraints/_positional.py
+++ b/src/m4opt/constraints/_positional.py
@@ -35,6 +35,7 @@ class AngleConstraint(Constraint):
     @abstractmethod
     def _frame(self, observer_location: EarthLocation, obstime: Time):
         """Frame for this constraint"""
+        raise NotImplementedError
 
     def _get_angle(
         self, observer_location: EarthLocation, target_coord: SkyCoord, obstime: Time

--- a/src/m4opt/dynamics/_slew.py
+++ b/src/m4opt/dynamics/_slew.py
@@ -200,6 +200,7 @@ class Slew(ABC):
         :
             Time to slew between the two orientations.
         """
+        raise NotImplementedError
 
 
 @dataclass

--- a/src/m4opt/observer/_core.py
+++ b/src/m4opt/observer/_core.py
@@ -21,3 +21,4 @@ class ObserverLocation(ABC):
         :
             The Earth-relative coordinates of the satellite.
         """
+        raise NotImplementedError

--- a/src/m4opt/synphot/_extrinsic.py
+++ b/src/m4opt/synphot/_extrinsic.py
@@ -56,6 +56,7 @@ class ScaleFactor(ABC, Model):
     @abstractmethod
     def value(self) -> float:
         """Return the value of the scale factor."""
+        raise NotImplementedError
 
     def __call__(self, x):
         return self.evaluate(x)
@@ -74,6 +75,7 @@ class ExtrinsicScaleFactor(ScaleFactor):
         self, observer_location: EarthLocation, target_coord: SkyCoord, obstime: Time
     ) -> float:
         """Evaluate the scale factor at a particular observerd location, target coordinate, and time."""
+        raise NotImplementedError
 
     @property
     def value(self) -> float:


### PR DESCRIPTION
In Python, a class must implement all of its bases abstract methods in order to be instantiated, but the base class abstract methods may still be called. This is a potential footgun (see #549).