### PR TITLE
Add AntiSolarSeparationConstraint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changes
 
 - Add ``EclipticLatitudeConstraint``.
 
+- Add ``AntiSolarSeparationConstraint`` to keep targets away from the
+  anti-solar point, where the nominal spacecraft roll angle is undefined.
+
 - Fix ``LogicalNotConstraint``, which ignored its operand and always
   evaluated to a scalar ``True``.
 

--- a/src/m4opt/constraints/__init__.py
+++ b/src/m4opt/constraints/__init__.py
@@ -1,6 +1,10 @@
 from ._airmass import AirmassConstraint
 from ._atnight import AtNightConstraint
-from ._body_separation import MoonSeparationConstraint, SunSeparationConstraint
+from ._body_separation import (
+    AntiSolarSeparationConstraint,
+    MoonSeparationConstraint,
+    SunSeparationConstraint,
+)
 from ._core import Constraint
 from ._earth_limb import EarthLimbConstraint
 from ._galactic import GalacticLatitudeConstraint
@@ -19,6 +23,7 @@ from ._radiation import RadiationBeltConstraint
 __all__ = (
     "AirmassConstraint",
     "AltitudeConstraint",
+    "AntiSolarSeparationConstraint",
     "AtNightConstraint",
     "AzimuthConstraint",
     "Constraint",

--- a/src/m4opt/constraints/_body_separation.py
+++ b/src/m4opt/constraints/_body_separation.py
@@ -88,42 +88,39 @@ class SunSeparationConstraint(BodySeparationConstraint):
         super().__init__(min, "sun")
 
 
-class AntiSolarSeparationConstraint(BodySeparationConstraint):
-    def __init__(self, min: u.Quantity[u.physical.angle]):
-        """
-        Constrain the minimum separation from the anti-solar point.
+class AntiSolarSeparationConstraint(SunSeparationConstraint):
+    """
+    Constrain the minimum separation from the anti-solar point.
 
-        The anti-solar point is the point on the sky directly opposite the
-        Sun (solar elongation of 180°). The nominal spacecraft roll angle
-        (see :func:`~m4opt.dynamics.nominal_roll`) is undefined there, and
-        changes arbitrarily fast nearby, so it is generally necessary to
-        keep targets away from it by some margin.
+    The anti-solar point is the point on the sky directly opposite the
+    Sun. The nominal spacecraft roll angle
+    (see :func:`~m4opt.dynamics.nominal_roll`) is undefined there, and
+    changes arbitrarily fast nearby.
 
-        Parameters
-        ----------
-        min
-            Minimum angular separation from the anti-solar point.
+    Parameters
+    ----------
+    min
+        Minimum angular separation from the anti-solar point.
 
-        See Also
-        --------
-        m4opt.constraints.SunSeparationConstraint
-        m4opt.dynamics.nominal_roll
+    See Also
+    --------
+    m4opt.constraints.SunSeparationConstraint
+    m4opt.dynamics.nominal_roll
 
-        Examples
-        --------
+    Examples
+    --------
 
-        >>> from astropy.coordinates import EarthLocation, SkyCoord
-        >>> from astropy.time import Time
-        >>> from astropy import units as u
-        >>> from m4opt.constraints import AntiSolarSeparationConstraint
-        >>> time = Time("2017-08-17T12:41:04Z")
-        >>> target = SkyCoord.from_name("NGC 4993")
-        >>> location = EarthLocation.of_site("Las Campanas Observatory")
-        >>> constraint = AntiSolarSeparationConstraint(20 * u.deg)
-        >>> constraint(location, target, time)
-        np.True_
-        """
-        super().__init__(min, "sun")
+    >>> from astropy.coordinates import EarthLocation, SkyCoord
+    >>> from astropy.time import Time
+    >>> from astropy import units as u
+    >>> from m4opt.constraints import AntiSolarSeparationConstraint
+    >>> time = Time("2017-08-17T12:41:04Z")
+    >>> target = SkyCoord.from_name("NGC 4993")
+    >>> location = EarthLocation.of_site("Las Campanas Observatory")
+    >>> constraint = AntiSolarSeparationConstraint(20 * u.deg)
+    >>> constraint(location, target, time)
+    np.True_
+    """
 
     @override
     def _separation(self, observer_location, target_coord, obstime):

--- a/src/m4opt/constraints/_body_separation.py
+++ b/src/m4opt/constraints/_body_separation.py
@@ -63,6 +63,7 @@ class SunSeparationConstraint(BodySeparationConstraint):
 
         See Also
         --------
+        m4opt.constraints.AntiSolarSeparationConstraint
         m4opt.constraints.EclipticLatitudeConstraint
         m4opt.constraints.HelioeclipticLongitudeConstraint
 
@@ -85,3 +86,50 @@ class SunSeparationConstraint(BodySeparationConstraint):
         np.True_
         """
         super().__init__(min, "sun")
+
+
+class AntiSolarSeparationConstraint(Constraint):
+    def __init__(self, min: u.Quantity[u.physical.angle]):
+        """
+        Constrain the minimum separation from the anti-solar point.
+
+        The anti-solar point is the point on the sky directly opposite the
+        Sun (solar elongation of 180°). The nominal spacecraft roll angle
+        (see :func:`~m4opt.dynamics.nominal_roll`) is undefined there, and
+        changes arbitrarily fast nearby, so it is generally necessary to
+        keep targets away from it by some margin.
+
+        Parameters
+        ----------
+        min
+            Minimum angular separation from the anti-solar point.
+
+        See Also
+        --------
+        m4opt.constraints.SunSeparationConstraint
+        m4opt.dynamics.nominal_roll
+
+        Examples
+        --------
+
+        >>> from astropy.coordinates import EarthLocation, SkyCoord
+        >>> from astropy.time import Time
+        >>> from astropy import units as u
+        >>> from m4opt.constraints import AntiSolarSeparationConstraint
+        >>> time = Time("2017-08-17T12:41:04Z")
+        >>> target = SkyCoord.from_name("NGC 4993")
+        >>> location = EarthLocation.of_site("Las Campanas Observatory")
+        >>> constraint = AntiSolarSeparationConstraint(20 * u.deg)
+        >>> constraint(location, target, time)
+        np.True_
+        """
+        self.min = min
+
+    @override
+    def __call__(self, observer_location, target_coord, obstime):
+        return (
+            180 * u.deg
+            - get_body("sun", time=obstime, location=observer_location).separation(
+                target_coord, origin_mismatch="ignore"
+            )
+        ) >= self.min

--- a/src/m4opt/constraints/_body_separation.py
+++ b/src/m4opt/constraints/_body_separation.py
@@ -11,14 +11,14 @@ class BodySeparationConstraint(Constraint):
         self._body = body
         self.min = min
 
+    def _separation(self, observer_location, target_coord, obstime):
+        return get_body(
+            self._body, time=obstime, location=observer_location
+        ).separation(target_coord, origin_mismatch="ignore")
+
     @override
     def __call__(self, observer_location, target_coord, obstime):
-        return (
-            get_body(self._body, time=obstime, location=observer_location).separation(
-                target_coord, origin_mismatch="ignore"
-            )
-            >= self.min
-        )
+        return self._separation(observer_location, target_coord, obstime) >= self.min
 
 
 class MoonSeparationConstraint(BodySeparationConstraint):
@@ -88,7 +88,7 @@ class SunSeparationConstraint(BodySeparationConstraint):
         super().__init__(min, "sun")
 
 
-class AntiSolarSeparationConstraint(Constraint):
+class AntiSolarSeparationConstraint(BodySeparationConstraint):
     def __init__(self, min: u.Quantity[u.physical.angle]):
         """
         Constrain the minimum separation from the anti-solar point.
@@ -123,13 +123,10 @@ class AntiSolarSeparationConstraint(Constraint):
         >>> constraint(location, target, time)
         np.True_
         """
-        self.min = min
+        super().__init__(min, "sun")
 
     @override
-    def __call__(self, observer_location, target_coord, obstime):
-        return (
-            180 * u.deg
-            - get_body("sun", time=obstime, location=observer_location).separation(
-                target_coord, origin_mismatch="ignore"
-            )
-        ) >= self.min
+    def _separation(self, observer_location, target_coord, obstime):
+        return 180 * u.deg - super()._separation(
+            observer_location, target_coord, obstime
+        )

--- a/src/m4opt/constraints/tests/test_body_separation.py
+++ b/src/m4opt/constraints/tests/test_body_separation.py
@@ -5,12 +5,16 @@ from astroplan import MoonSeparationConstraint as AstroplanMoonSeparationConstra
 from astroplan import Observer
 from astroplan import SunSeparationConstraint as AstroplanSunSeparationConstraint
 from astropy import units as u
-from astropy.coordinates import NonRotationTransformationWarning
-from hypothesis import given, settings
+from astropy.coordinates import NonRotationTransformationWarning, get_body
+from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 
 from ...tests.hypothesis import earth_locations, obstimes, skycoords
-from .._body_separation import MoonSeparationConstraint, SunSeparationConstraint
+from .._body_separation import (
+    AntiSolarSeparationConstraint,
+    MoonSeparationConstraint,
+    SunSeparationConstraint,
+)
 
 
 @settings(deadline=None)
@@ -34,4 +38,23 @@ def test_astroplan(
         expected = astroplan_constraint(
             Observer(observer_location), target_coord, obstime
         )
+    assert result == expected
+
+
+@settings(deadline=None)
+@given(earth_locations, skycoords, obstimes, st.floats(0, 180))
+def test_anti_solar_separation(observer_location, target_coord, obstime, min_sep_deg):
+    """Test that AntiSolarSeparationConstraint agrees with 180° minus the
+    solar elongation."""
+    min_sep = min_sep_deg * u.deg
+    with catch_warnings(action="ignore", category=NonRotationTransformationWarning):
+        sun_separation = get_body(
+            "sun", time=obstime, location=observer_location
+        ).separation(target_coord, origin_mismatch="ignore")
+    anti_solar_separation = 180 * u.deg - sun_separation
+    # Avoid the boundary, where floating point error could flip the result.
+    assume(abs(anti_solar_separation - min_sep) > 1e-6 * u.deg)
+    constraint = AntiSolarSeparationConstraint(min_sep)
+    result = constraint(observer_location, target_coord, obstime)
+    expected = anti_solar_separation >= min_sep
     assert result == expected


### PR DESCRIPTION
Added a new constraint (``AntiSolarSeparationConstraint``) to the ``m4opt.constraints`` module which can be used to prevent instruments from targeting the anti-sun direction. 

## Justification / Discussion

As noted in [m4opt/uvex-scheduler#30](https://github.com/m4opt/uvex-scheduler/issues/30), the nominal roll field $\boldsymbol{\psi}(\hat{\bf n}, t) \in T(S^2)$ is not smooth at the sun and anti-sun positions. In the [UVEX scheduler](https://github.com/m4opt/uvex-scheduler), this can result in long slews between adjacent fields within a single observing block if that block contains either the sun or anti-sun points at its scheduled time. Currently, ``m4opt.missions._uvex`` prevents the instrument from pointing at the sun, but does not prevent it from pointing at the anti-sun point. 

This PR simply implements an ``AntiSolarSeparationConstraint`` which can be added to the UVEX mission (not done here) to prevent this pathology from arising. 

## Notes

Unlike the ``SunSeparationConstraint``, which requires a reasonably large solid angle of exclusion, the anti-sun separation constraint may be treated as effectively point-like (the field is everywhere else smooth), and so the ``min`` parameter can be made quite small.