### PR TITLE
Add count_intersect1d_combinations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,14 @@ Changes
 
 - Add ``m4opt.utils.functional.apply`` method.
 
+- Add the function ``count_intersect1d_combinations`` to calculate the overlap
+  of pairwise combinations of arrays, parallelized with OpenMP.
+
+  This operation is needed to calculate per-pixel cadence distributions from
+  HEALPix observation footprints. The specialized parallel version is necessary
+  because ``count_intersect1d`` cannot be effectively parallelized using Python
+  techniques like ``multiprocessing``.
+
 2.11.0 (2026-08-18)
 ===================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,3 +159,6 @@ ignore-words-list = """
 select = "cp3??t-*"
 inherit.environment = "append"
 environment.EXTENSION_HELPERS_PY_LIMITED_API = ""
+
+[tool.cibuildwheel.macos]
+before-build = "brew install libomp"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,10 +173,8 @@ inherit.environment = "append"
 environment.MACOSX_DEPLOYMENT_TARGET = "14.0"
 
 [tool.cibuildwheel.macos]
-before-all = "brew install llvm@15 libomp"
+before-all = "brew install libomp"
 
 [tool.cibuildwheel.macos.environment]
-CC = "$(brew --prefix llvm@15)/bin/clang"
-CXX = "$(brew --prefix llvm@15)/bin/clang++"
 CPPFLAGS = "-I$(brew --prefix libomp)/include"
 LDFLAGS = "-L$(brew --prefix libomp)/lib"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,4 +161,10 @@ inherit.environment = "append"
 environment.EXTENSION_HELPERS_PY_LIMITED_API = ""
 
 [tool.cibuildwheel.macos]
-before-build = "brew install libomp"
+before-all = "brew install llvm@23 libomp"
+
+[tool.cibuildwheel.macos.environment]
+CC = "$(brew --prefix llvm@23)/bin/clang"
+CXX = "$(brew --prefix llvm@23)/bin/clang++"
+CPPFLAGS = "-I$(brew --prefix libomp)/include"
+LDFLAGS = "-L$(brew --prefix libomp)/lib"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,10 +161,10 @@ inherit.environment = "append"
 environment.EXTENSION_HELPERS_PY_LIMITED_API = ""
 
 [tool.cibuildwheel.macos]
-before-all = "brew install llvm@23 libomp"
+before-all = "brew install llvm@15 libomp"
 
 [tool.cibuildwheel.macos.environment]
-CC = "$(brew --prefix llvm@23)/bin/clang"
-CXX = "$(brew --prefix llvm@23)/bin/clang++"
+CC = "$(brew --prefix llvm@15)/bin/clang"
+CXX = "$(brew --prefix llvm@15)/bin/clang++"
 CPPFLAGS = "-I$(brew --prefix libomp)/include"
 LDFLAGS = "-L$(brew --prefix libomp)/lib"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,18 @@ select = "cp3??t-*"
 inherit.environment = "append"
 environment.EXTENSION_HELPERS_PY_LIMITED_API = ""
 
+[[tool.cibuildwheel.overrides]]
+# macOS x86_64 wheels are built on GitHub on macOS 15; set deployment target accordingly
+select = "*macosx_x86_64"
+inherit.environment = "append"
+environment.MACOSX_DEPLOYMENT_TARGET = "15.0"
+
+[[tool.cibuildwheel.overrides]]
+# macOS arm64 wheels are built on GitHub on macOS 14; set deployment target accordingly
+select = "*macosx_arm64"
+inherit.environment = "append"
+environment.MACOSX_DEPLOYMENT_TARGET = "14.0"
+
 [tool.cibuildwheel.macos]
 before-all = "brew install llvm@15 libomp"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,8 +173,10 @@ inherit.environment = "append"
 environment.MACOSX_DEPLOYMENT_TARGET = "14.0"
 
 [tool.cibuildwheel.macos]
-before-all = "brew install libomp"
+before-all = "brew install llvm@15 libomp"
 
 [tool.cibuildwheel.macos.environment]
+CC = "$(brew --prefix llvm@15)/bin/clang"
+CXX = "$(brew --prefix llvm@15)/bin/clang++"
 CPPFLAGS = "-I$(brew --prefix libomp)/include"
 LDFLAGS = "-L$(brew --prefix libomp)/lib"

--- a/src/m4opt/utils/_numpy.c
+++ b/src/m4opt/utils/_numpy.c
@@ -119,8 +119,109 @@ done:
     return result;
 }
 
+static PyObject *py_count_intersect1d_combinations(PyObject *NPY_UNUSED(self), PyObject *arg) {
+    Py_ssize_t num_arrays = PySequence_Length(arg);
+    if (num_arrays < 0) return NULL;
+    if (num_arrays < 2)
+    {
+        PyErr_Format(
+            PyExc_ValueError,
+            "count_intersect1d_combinations() expects a sequence of at least 2 arrays (%zd given)",
+            (ssize_t) num_arrays
+        );
+        return NULL;
+    }
+
+    PyObject *result = NULL;
+    Py_ssize_t result_len = num_arrays * (num_arrays - 1) / 2;
+    PyObject **arrays = PyMem_Malloc(sizeof(PyObject *) * num_arrays);
+    const npy_intp **data = PyMem_Malloc(sizeof(const npy_intp *) * num_arrays);
+    npy_intp *n = PyMem_Malloc(sizeof(npy_intp) * num_arrays);
+    Py_ssize_t *is = PyMem_Malloc(sizeof(Py_ssize_t) * result_len);
+    Py_ssize_t *js = PyMem_Malloc(sizeof(Py_ssize_t) * result_len);
+    if (!(arrays && data && n))
+    {
+        PyErr_NoMemory();
+        goto free_arrays;
+    }
+
+    // Get pointers to the Numpy data for each input array.
+    // It's important to do this here rather than in the computation loop below
+    // so that the Python overhead grow like O(N) rather than O(N^2) in the
+    // number of arrays N.
+    for (Py_ssize_t i = 0; i < num_arrays; i ++) arrays[i] = NULL;
+    for (Py_ssize_t i = 0; i < num_arrays; i ++)
+    {
+        PyObject *item = PySequence_GetItem(arg, i);
+        if (!item) goto decref_objects;
+        PyObject *array = PyArray_FROMANY(item, NPY_INTP, 1, 1, NPY_ARRAY_CARRAY_RO);
+        Py_DECREF(item);
+        if (!array) goto decref_objects;
+        arrays[i] = array;
+        data[i] = (const npy_intp *) PyArray_DATA((PyArrayObject *) array);
+        n[i] = PyArray_SIZE((PyArrayObject *) array);
+    }
+
+    // Allocate output array. If there are N input arrays, then the output
+    // array size is given by the binomial coefficient:
+    //
+    //      ⎛ N ⎞
+    //      ⎜   ⎟
+    //      ⎝ 2 ⎠
+    //
+    if (!(result = PyArray_SimpleNew(1, &result_len, NPY_INTP))) goto decref_objects;
+    npy_intp *result_data = PyArray_DATA((PyArrayObject *) result);
+
+    Py_BEGIN_ALLOW_THREADS;
+    // Build lookup table from output index to input indices.
+    {
+        Py_ssize_t result_i = 0;
+        for (Py_ssize_t i = 0; i < num_arrays; i ++)
+        {
+            for (Py_ssize_t j = i + 1; j < num_arrays; j ++)
+            {
+                is[result_i] = i;
+                js[result_i] = j;
+                result_i++;
+            }
+        }
+    }
+    // The lookup tables ``is`` and ``js`` defined above allow us to correctly
+    // parallelize the following loop, which otherwise would only be correct
+    // when executed serially because of the order-dependent increment of ``k``
+    // inside the loop body. It also results in more efficient parallelism
+    // because the work per loop is more balanced.
+    //
+    //      // incorrect, inefficient
+    //      Py_ssize_t k = 0;
+    //      #pragma omp parallel for
+    //      for (Py_ssize_t i = 0; i < num_arrays; i ++)
+    //          for (Py_ssize_t j = i + 1; j < num_arrays; j ++)
+    //              result_data[k++] = count_intersect1d(data[i], data[j], n[i], n[j]);
+    //
+    #pragma omp parallel for
+    for (Py_ssize_t result_i = 0; result_i < result_len; result_i ++)
+    {
+        Py_ssize_t i = is[result_i], j = js[result_i];
+        result_data[result_i] = count_intersect1d(data[i], data[j], n[i], n[j]);
+    }
+    Py_END_ALLOW_THREADS;
+
+decref_objects:
+    for (Py_ssize_t i = 0; i < num_arrays; i++)
+        Py_XDECREF(arrays[i]);
+free_arrays:
+    PyMem_Free(arrays);
+    PyMem_Free(data);
+    PyMem_Free(n);
+    PyMem_Free(is);
+    PyMem_Free(js);
+    return result;
+}
+
 static PyMethodDef methods[] = {
     {"count_intersect1d", (PyCFunction)py_count_intersect1d, METH_FASTCALL},
+    {"count_intersect1d_combinations", (PyCFunction)py_count_intersect1d_combinations, METH_O},
     {/* Sentinel */}
 };
 

--- a/src/m4opt/utils/numpy.py
+++ b/src/m4opt/utils/numpy.py
@@ -140,13 +140,12 @@ def count_intersect1d_combinations(
     All pairs are evaluated in parallel using OpenMP. This is equivalent to,
     but much faster than::
 
-        from functools import combinations
+        from itertools import combinations
 
         from m4opt.utils.numpy import count_intersect1d
-        import numpy as np
 
         def count_intersect1d_combinations_slow(arrays):
-            return [count_intersect1d(args) for args in combinations(arrays, 2)]
+            return [count_intersect1d(*args) for args in combinations(arrays, 2)]
 
     Parameters
     ----------

--- a/src/m4opt/utils/numpy.py
+++ b/src/m4opt/utils/numpy.py
@@ -150,13 +150,13 @@ def count_intersect1d_combinations(
     Parameters
     ----------
     arrays
-        A list of sorted 1D array of type :obj:`numpy.intp`.
+        A list of sorted 1D arrays of type :obj:`numpy.intp`.
 
     Returns
     -------
     :
-        An array consisting of the elements that are in each pairwsise
-        combination.
+        The number of elements in common for each pairwise combination, in the
+        order produced by :func:`itertools.combinations`.
 
     Notes
     -----

--- a/src/m4opt/utils/numpy.py
+++ b/src/m4opt/utils/numpy.py
@@ -3,13 +3,19 @@
 import numpy as np
 from numpy import typing as npt
 
-from ._numpy import count_intersect1d as _count_intersect1d
+from ._numpy import (
+    count_intersect1d as _count_intersect1d,
+)
+from ._numpy import (
+    count_intersect1d_combinations as _count_intersect1d_combinations,
+)
 
 __all__ = (
     "atmost_1d",
     "clump_nonzero",
     "clump_nonzero_inclusive",
     "count_intersect1d",
+    "count_intersect1d_combinations",
     "full_indices",
 )
 
@@ -124,6 +130,43 @@ def count_intersect1d(a: npt.ArrayLike, b: npt.ArrayLike) -> int:
     1
     """
     return _count_intersect1d(a, b)
+
+
+def count_intersect1d_combinations(
+    arrays: list[npt.ArrayLike],
+) -> np.ndarray[tuple[int], np.dtype[np.intp]]:
+    """Calculate the cardinalities of the intersections of all pairwise combinations.
+
+    All pairs are evaluated in parallel using OpenMP. This is equivalent to,
+    but much faster than::
+
+        from functools import combinations
+
+        from m4opt.utils.numpy import count_intersect1d
+        import numpy as np
+
+        def count_intersect1d_combinations_slow(arrays):
+            return [count_intersect1d(args) for args in combinations(arrays, 2)]
+
+    Parameters
+    ----------
+    arrays
+        A list of sorted 1D array of type :obj:`numpy.intp`.
+
+    Returns
+    -------
+    :
+        An array consisting of the elements that are in each pairwsise
+        combination.
+
+    Notes
+    -----
+    This calculation cannot be effectively parallelized using traditional
+    Python techniques like :mod:`multiprocessing` because the inherently
+    sequential Python overhead of processing the arguments would grow as O(N^2)
+    with the number of input arrays N.
+    """
+    return _count_intersect1d_combinations(arrays)
 
 
 def full_indices(n):

--- a/src/m4opt/utils/setup_package.py
+++ b/src/m4opt/utils/setup_package.py
@@ -2,16 +2,17 @@ import numpy as np
 
 
 def get_extensions():
+    from extension_helpers import add_openmp_flags_if_available
     from setuptools import Extension
 
-    return [
-        Extension(
-            "m4opt.utils._numpy",
-            ["src/m4opt/utils/_numpy.c"],
-            define_macros=[
-                ("NPY_TARGET_VERSION", "NPY_2_0_API_VERSION"),
-                ("NPY_NO_DEPRECATED_API", "NPY_2_0_API_VERSION"),
-            ],
-            include_dirs=[np.get_include()],
-        )
-    ]
+    ext = Extension(
+        "m4opt.utils._numpy",
+        ["src/m4opt/utils/_numpy.c"],
+        define_macros=[
+            ("NPY_TARGET_VERSION", "NPY_2_0_API_VERSION"),
+            ("NPY_NO_DEPRECATED_API", "NPY_2_0_API_VERSION"),
+        ],
+        include_dirs=[np.get_include()],
+    )
+    add_openmp_flags_if_available(ext)
+    return [ext]

--- a/src/m4opt/utils/tests/test_numpy.py
+++ b/src/m4opt/utils/tests/test_numpy.py
@@ -54,7 +54,6 @@ def test_count_intersect1d_combinations(arrays):
 
 @pytest.mark.parametrize("n", [0, 1])
 def test_count_intersect1d_combinations_too_few_args(n):
-    """Test that we don't run out of stack memory for large numbers of inputs."""
     with pytest.raises(
         ValueError,
         match=rf"count_intersect1d_combinations\(\) expects a sequence of at least 2 arrays \({n} given\)",

--- a/src/m4opt/utils/tests/test_numpy.py
+++ b/src/m4opt/utils/tests/test_numpy.py
@@ -1,9 +1,13 @@
+from itertools import combinations
+from math import comb
+
 import numpy as np
 import pytest
 from hypothesis import given
+from hypothesis import strategies as st
 from hypothesis.extra import numpy as xp
 
-from ..numpy import count_intersect1d
+from ..numpy import count_intersect1d, count_intersect1d_combinations
 
 sets1d = xp.arrays(
     dtype=np.intp,
@@ -32,5 +36,49 @@ def setup():
 
 
 @pytest.mark.parametrize("implementation", (count_intersect1d, count_intersect1d_slow))
-def test_benchmark(implementation, benchmark):
+def test_benchmark_count_intersect1d(implementation, benchmark):
     benchmark.pedantic(implementation, setup=setup, rounds=100, warmup_rounds=1)
+
+
+def count_intersect1d_combinations_slow(a):
+    return np.asarray([count_intersect1d(*args) for args in combinations(a, 2)])
+
+
+@given(arrays=st.lists(sets1d, min_size=2))
+def test_count_intersect1d_combinations(arrays):
+    np.testing.assert_array_equal(
+        count_intersect1d_combinations(arrays),
+        count_intersect1d_combinations_slow(arrays),
+    )
+
+
+@pytest.mark.parametrize("n", [0, 1])
+def test_count_intersect1d_combinations_too_few_args(n):
+    """Test that we don't run out of stack memory for large numbers of inputs."""
+    with pytest.raises(
+        ValueError,
+        match=rf"count_intersect1d_combinations\(\) expects a sequence of at least 2 arrays \({n} given\)",
+    ):
+        count_intersect1d_combinations([[]] * n)
+
+
+def test_count_intersect1d_combinations_very_large():
+    """Test that we don't run out of stack memory for large numbers of inputs."""
+    n = 2000
+    np.testing.assert_array_equal(
+        count_intersect1d_combinations([[]] * n), np.zeros(comb(n, 2), dtype=np.intp)
+    )
+
+
+def setup_combinations():
+    return ([setup_set1d() for _ in range(20)],), {}
+
+
+@pytest.mark.parametrize(
+    "implementation",
+    (count_intersect1d_combinations, count_intersect1d_combinations_slow),
+)
+def test_benchmark_count_intersect1d_combinations(implementation, benchmark):
+    benchmark.pedantic(
+        implementation, setup=setup_combinations, rounds=10, warmup_rounds=1
+    )


### PR DESCRIPTION
Add the function `count_intersect1d_combinations` to calculate the overlap of pairwise combinations of arrays, parallelized with OpenMP.

This operation is needed to calculate per-pixel cadence distributions from HEALPix observation footprints. The specialized parallel version is necessary because `count_intersect1d` cannot be effectively parallelized using Python techniques like `multiprocessing`.