### PR TITLE
Skip a test whose fixture exceeds the CPLEX problem size

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,9 @@ Changes
 - Fix the ULTRASAT readout noise, which was set to the noise budget's
   variance (6 e-/pix) rather than its RMS.
 
+- Skip a test whose fixture exceeds the problem size that the installed CPLEX
+  license allows, as was already done for the body of a test.
+
 2.12.0 (2026-08-28)
 ===================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,9 +36,6 @@ Changes
 - Fix the ULTRASAT readout noise, which was set to the noise budget's
   variance (6 e-/pix) rather than its RMS.
 
-- Skip a test whose fixture exceeds the problem size that the installed CPLEX
-  license allows, as was already done for the body of a test.
-
 2.12.0 (2026-08-28)
 ===================
 

--- a/src/m4opt/conftest.py
+++ b/src/m4opt/conftest.py
@@ -13,9 +13,12 @@ import numpy as np
 import pytest
 from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 
-from .tests.plugins.problem_size_limits import pytest_runtest_call  # noqa: F401
+from .tests.plugins.problem_size_limits import (  # noqa: F401
+    pytest_runtest_call,
+    pytest_runtest_setup,
+)
 
-pytest_plugins = ["sphinx.testing.fixtures"]
+pytest_plugins = ["sphinx.testing.fixtures", "pytester"]
 
 
 def pytest_configure(config):

--- a/src/m4opt/tests/plugins/problem_size_limits.py
+++ b/src/m4opt/tests/plugins/problem_size_limits.py
@@ -2,11 +2,22 @@ import pytest
 from docplex.mp.utils import DOcplexLimitsExceeded
 
 
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_call(item):
-    """Skip tests that exceed the Gurobi or CPLEX problem size."""
-    outcome = yield
+def _skip_if_problem_too_large(outcome):
     if outcome.excinfo is not None and issubclass(
         outcome.excinfo[0], DOcplexLimitsExceeded
     ):
         pytest.skip("requires full version of CPLEX")
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_setup(item):
+    """Skip tests whose fixtures exceed the CPLEX problem size."""
+    outcome = yield
+    _skip_if_problem_too_large(outcome)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call(item):
+    """Skip tests that exceed the CPLEX problem size."""
+    outcome = yield
+    _skip_if_problem_too_large(outcome)

--- a/src/m4opt/tests/plugins/tests/test_problem_size_limits.py
+++ b/src/m4opt/tests/plugins/tests/test_problem_size_limits.py
@@ -1,0 +1,53 @@
+"""Tests for skipping problems that exceed the solver's licensed size."""
+
+import pytest
+
+CONFTEST = """
+from m4opt.tests.plugins.problem_size_limits import (  # noqa: F401
+    pytest_runtest_call,
+    pytest_runtest_setup,
+)
+"""
+
+SOURCE = '''
+import pytest
+from docplex.mp.utils import DOcplexLimitsExceeded
+
+
+def too_big():
+    raise DOcplexLimitsExceeded(10000, 10000)
+
+
+@pytest.fixture
+def solved():
+    too_big()
+
+
+def test_from_a_fixture(solved):
+    pass
+
+
+def test_from_the_body():
+    too_big()
+
+
+def test_unrelated_error_is_not_skipped():
+    raise ValueError("something else")
+'''
+
+
+@pytest.fixture
+def run(pytester):
+    pytester.makeconftest(CONFTEST)
+    pytester.makepyfile(SOURCE)
+    return pytester.runpytest()
+
+
+def test_the_size_limit_becomes_a_skip(run):
+    """A solve in a fixture is raised during setup, not during the call."""
+    run.assert_outcomes(skipped=2, failed=1)
+
+
+def test_an_unrelated_error_still_fails(run):
+    """Only the size limit is turned into a skip."""
+    run.stdout.fnmatch_lines(["*test_unrelated_error_is_not_skipped*"])

--- a/src/m4opt/tests/plugins/tests/test_problem_size_limits.py
+++ b/src/m4opt/tests/plugins/tests/test_problem_size_limits.py
@@ -9,7 +9,7 @@ from m4opt.tests.plugins.problem_size_limits import (  # noqa: F401
 )
 """
 
-SOURCE = '''
+SOURCE = """
 import pytest
 from docplex.mp.utils import DOcplexLimitsExceeded
 
@@ -33,7 +33,7 @@ def test_from_the_body():
 
 def test_unrelated_error_is_not_skipped():
     raise ValueError("something else")
-'''
+"""
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR skips a test whose fixture exceeds the CPLEX problem size (I ran into this when testing https://github.com/m4opt/m4opt/pull/574).